### PR TITLE
Toggle bottom bar item off on mobile

### DIFF
--- a/src/components/mobile/MobileToolbar.tsx
+++ b/src/components/mobile/MobileToolbar.tsx
@@ -216,7 +216,12 @@ export function MobileToolbar({ onOpenPanel }: MobileToolbarProps) {
   };
 
   const handleToolSelect = (tool: Tool, closeMenu: boolean = false) => {
-    setTool(tool);
+    // If the tool is already selected and it's not 'select', toggle back to select
+    if (selectedTool === tool && tool !== 'select') {
+      setTool('select');
+    } else {
+      setTool(tool);
+    }
     setExpandedCategory(null);
     if (closeMenu) {
       setShowMenu(false);


### PR DESCRIPTION
Allow mobile bottom bar items to be toggled off by tapping them again, returning to 'select' mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ec7e3f-9421-4497-b1ff-347d7b6f6af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5ec7e3f-9421-4497-b1ff-347d7b6f6af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

