### PR TITLE
Update mobile toolbar road icon

### DIFF
--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -66,8 +66,12 @@ export function CloseIcon({ size = 18, className }: IconProps) {
 export function RoadIcon({ size = 18, className }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" className={className}>
-      <path {...baseStroke} d="M9 3h6l-1.5 18h-3z" />
-      <path {...baseStroke} d="M12 6v3M12 12v3M12 18v1" />
+      {/* Road surface */}
+      <rect {...baseStroke} x="6" y="4" width="12" height="16" rx="1" />
+      {/* Center lane divider */}
+      <path {...baseStroke} d="M12 6v12" strokeDasharray="2 2" />
+      {/* Side edges */}
+      <path {...baseStroke} d="M6 8h12M6 16h12" />
     </svg>
   );
 }


### PR DESCRIPTION
Replace the mobile toolbar's road icon with a clearer top-down design.

---
<a href="https://cursor.com/background-agent?bcId=bc-85eef01f-1094-463f-bc5a-f8ae2db8be87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85eef01f-1094-463f-bc5a-f8ae2db8be87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

