### PR TITLE
Rearrange mobile toolbar and overlay menu

### DIFF
--- a/src/components/mobile/MobileToolbar.tsx
+++ b/src/components/mobile/MobileToolbar.tsx
@@ -332,9 +332,61 @@ export function MobileToolbar({ onOpenPanel }: MobileToolbarProps) {
             className="absolute bottom-20 left-2 right-2 max-h-[70vh] overflow-hidden rounded-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="p-3 border-b border-border flex items-center justify-between">
-              <span className="font-semibold text-sm">Build Menu</span>
-              <span className="text-muted-foreground text-xs font-mono">${stats.money.toLocaleString()}</span>
+            {/* City Management section at top */}
+            <div className="p-3 border-b border-border">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-xs text-muted-foreground uppercase tracking-wider">
+                  City Management
+                </div>
+                <span className="text-muted-foreground text-xs font-mono">${stats.money.toLocaleString()}</span>
+              </div>
+              <div className="grid grid-cols-5 gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-12 w-full flex-col gap-1"
+                  onClick={() => { onOpenPanel('budget'); setShowMenu(false); }}
+                >
+                  <BudgetIcon size={18} />
+                  <span className="text-[9px]">Budget</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-12 w-full flex-col gap-1"
+                  onClick={() => { onOpenPanel('statistics'); setShowMenu(false); }}
+                >
+                  <ChartIcon size={18} />
+                  <span className="text-[9px]">Stats</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-12 w-full flex-col gap-1"
+                  onClick={() => { onOpenPanel('advisors'); setShowMenu(false); }}
+                >
+                  <AdvisorIcon size={18} />
+                  <span className="text-[9px]">Advisors</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-12 w-full flex-col gap-1"
+                  onClick={() => { onOpenPanel('achievements'); setShowMenu(false); }}
+                >
+                  <TrophyIcon size={18} />
+                  <span className="text-[9px]">Awards</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-12 w-full flex-col gap-1"
+                  onClick={() => { onOpenPanel('settings'); setShowMenu(false); }}
+                >
+                  <SettingsIcon size={18} />
+                  <span className="text-[9px]">Settings</span>
+                </Button>
+              </div>
             </div>
 
             <ScrollArea className="h-[50vh]">
@@ -347,7 +399,6 @@ export function MobileToolbar({ onOpenPanel }: MobileToolbarProps) {
                       className="w-full justify-start gap-3 h-12"
                       onClick={() => handleCategoryClick(category)}
                     >
-                      <span className="text-muted-foreground">{CategoryIcons[category]}</span>
                       <span className="flex-1 text-left font-medium">{category}</span>
                       <svg
                         className={`w-4 h-4 transition-transform ${expandedCategory === category ? 'rotate-180' : ''}`}
@@ -376,9 +427,6 @@ export function MobileToolbar({ onOpenPanel }: MobileToolbarProps) {
                               disabled={!canAfford && info.cost > 0}
                               onClick={() => handleToolSelect(tool, true)}
                             >
-                              <span className="text-muted-foreground">
-                                {QuickToolIcons[tool] || <div className="w-5 h-5" />}
-                              </span>
                               <span className="flex-1 text-left">{info.name}</span>
                               {info.cost > 0 && (
                                 <span className={`text-xs font-mono ${canAfford ? 'text-green-400' : 'text-red-400'}`}>
@@ -392,60 +440,6 @@ export function MobileToolbar({ onOpenPanel }: MobileToolbarProps) {
                     )}
                   </div>
                 ))}
-
-                {/* Panels section */}
-                <div className="pt-2 mt-2 border-t border-border">
-                  <div className="text-xs text-muted-foreground uppercase tracking-wider px-3 py-2">
-                    City Management
-                  </div>
-                  <div className="grid grid-cols-5 gap-2 px-2">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-12 w-full flex-col gap-1"
-                      onClick={() => { onOpenPanel('budget'); setShowMenu(false); }}
-                    >
-                      <BudgetIcon size={18} />
-                      <span className="text-[9px]">Budget</span>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-12 w-full flex-col gap-1"
-                      onClick={() => { onOpenPanel('statistics'); setShowMenu(false); }}
-                    >
-                      <ChartIcon size={18} />
-                      <span className="text-[9px]">Stats</span>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-12 w-full flex-col gap-1"
-                      onClick={() => { onOpenPanel('advisors'); setShowMenu(false); }}
-                    >
-                      <AdvisorIcon size={18} />
-                      <span className="text-[9px]">Advisors</span>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-12 w-full flex-col gap-1"
-                      onClick={() => { onOpenPanel('achievements'); setShowMenu(false); }}
-                    >
-                      <TrophyIcon size={18} />
-                      <span className="text-[9px]">Awards</span>
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-12 w-full flex-col gap-1"
-                      onClick={() => { onOpenPanel('settings'); setShowMenu(false); }}
-                    >
-                      <SettingsIcon size={18} />
-                      <span className="text-[9px]">Settings</span>
-                    </Button>
-                  </div>
-                </div>
               </div>
             </ScrollArea>
           </Card>


### PR DESCRIPTION
Reorganize the mobile toolbar to prioritize city management, remove "Build Menu" text, display funds next to it, and declutter the drawer by removing icons.

---
<a href="https://cursor.com/background-agent?bcId=bc-63a768e6-ab6e-4fd8-9101-888a02e698f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63a768e6-ab6e-4fd8-9101-888a02e698f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

