### PR TITLE
Add hilly terrain generation and increase map size

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -5790,15 +5790,15 @@ function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile, isMob
         const y = sum - x;
         if (y < 0 || y >= gridSize) continue;
         
-        const { screenX, screenY } = gridToScreen(x, y, 0, 0);
-        
+        const tile = grid[y][x];
+        const { screenX, screenY } = gridToScreen(x, y, 0, 0, tile.elevation);
+
         // Viewport culling
         if (screenX + TILE_WIDTH < viewLeft || screenX > viewRight ||
             screenY + TILE_HEIGHT * 4 < viewTop || screenY > viewBottom) {
           continue;
         }
-        
-        const tile = grid[y][x];
+
         const isHovered = hoveredTile?.x === x && hoveredTile?.y === y;
         
         // Check if this tile is selected or part of a selected multi-tile building

--- a/src/components/game/utils.ts
+++ b/src/components/game/utils.ts
@@ -174,9 +174,16 @@ export function getDirectionToTile(fromX: number, fromY: number, toX: number, to
 }
 
 // Convert grid coordinates to screen coordinates (isometric)
-export function gridToScreen(x: number, y: number, offsetX: number, offsetY: number): { screenX: number; screenY: number } {
+export function gridToScreen(
+  x: number,
+  y: number,
+  offsetX: number,
+  offsetY: number,
+  elevation: number = 0
+): { screenX: number; screenY: number } {
   const screenX = (x - y) * (TILE_WIDTH / 2) + offsetX;
-  const screenY = (x + y) * (TILE_HEIGHT / 2) + offsetY;
+  const elevationOffset = elevation * TILE_HEIGHT * 0.6;
+  const screenY = (x + y) * (TILE_HEIGHT / 2) + offsetY - elevationOffset;
   return { screenX, screenY };
 }
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -131,6 +131,8 @@ export type Tool =
   | 'mountain_lodge'
   | 'mountain_trailhead';
 
+export const MAX_TERRAIN_ELEVATION = 8;
+
 export interface ToolInfo {
   name: string;
   cost: number;
@@ -213,6 +215,7 @@ export interface Building {
 export interface Tile {
   x: number;
   y: number;
+  elevation: number;
   zone: ZoneType;
   building: Building;
   landValue: number;


### PR DESCRIPTION
## Summary
- generate up to three elevated hills with grey peaks, keep water flat, and expand default map size by 10%
- flatten building footprints on placement to keep structures level on hilly terrain
- render elevation with shaded isometric sides and elevation-aware screen coordinates

## Testing
- npm run lint *(fails: pre-existing lint error and warnings in src/components/Game.tsx)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f6b349d08330be332dbdcc90211b)