### PR TITLE
Add hilly terrain and modify building placement

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -220,6 +220,7 @@ export interface Tile {
   crime: number;
   traffic: number;
   hasSubway: boolean;
+  elevation: number; // Terrain elevation (0 = flat, positive = hill height in tiles)
 }
 
 export interface Stats {
@@ -315,6 +316,14 @@ export interface WaterBody {
   centerY: number;
 }
 
+export interface Hill {
+  id: string;
+  centerX: number;
+  centerY: number;
+  radius: number; // Diameter is 10-15 tiles, so radius is 5-7.5
+  peakHeight: number; // 3-8 tiles of elevation
+}
+
 export interface GameState {
   grid: Tile[][];
   gridSize: number;
@@ -339,6 +348,7 @@ export interface GameState {
   disastersEnabled: boolean;
   adjacentCities: AdjacentCity[];
   waterBodies: WaterBody[];
+  hills: Hill[]; // Mountain/hill terrain features
 }
 
 // Building evolution paths based on zone and level


### PR DESCRIPTION
Add hilly terrain with grey mountain peaks, flatten terrain when placing buildings/zones, and increase map size by 10% to introduce more varied and realistic gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-910b3a96-a6fd-4342-87f8-5df169cead21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-910b3a96-a6fd-4342-87f8-5df169cead21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

