### PR TITLE
Reduce pedestrian density

### DIFF
--- a/src/components/game/constants.ts
+++ b/src/components/game/constants.ts
@@ -25,6 +25,7 @@ export const PEDESTRIAN_IDLE_CHANCE = 0.01;         // Chance to stop and idle b
 
 // Pedestrian performance limits
 export const PEDESTRIAN_MAX_COUNT = 800;            // Maximum pedestrians (hard cap)
+export const PEDESTRIAN_ROAD_TILE_DENSITY = 2.4;    // Target pedestrians per road tile (reduced from 3)
 export const PEDESTRIAN_SPAWN_BATCH_SIZE = 25;      // How many to try spawning at once
 export const PEDESTRIAN_SPAWN_INTERVAL = 0.03;      // Seconds between spawn batches
 export const PEDESTRIAN_UPDATE_SKIP_DISTANCE = 30;  // Skip detailed updates for pedestrians this far from view

--- a/src/components/game/vehicleSystems.ts
+++ b/src/components/game/vehicleSystems.ts
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { Car, CarDirection, EmergencyVehicle, EmergencyVehicleType, Pedestrian, PedestrianDestType, WorldRenderState, TILE_WIDTH, TILE_HEIGHT } from './types';
-import { CAR_COLORS, PEDESTRIAN_MIN_ZOOM, DIRECTION_META, PEDESTRIAN_MAX_COUNT, PEDESTRIAN_SPAWN_BATCH_SIZE, PEDESTRIAN_SPAWN_INTERVAL } from './constants';
+import { CAR_COLORS, PEDESTRIAN_MIN_ZOOM, DIRECTION_META, PEDESTRIAN_MAX_COUNT, PEDESTRIAN_ROAD_TILE_DENSITY, PEDESTRIAN_SPAWN_BATCH_SIZE, PEDESTRIAN_SPAWN_INTERVAL } from './constants';
 import { isRoadTile, getDirectionOptions, pickNextDirection, findPathOnRoads, getDirectionToTile, gridToScreen } from './utils';
 import { findResidentialBuildings, findPedestrianDestinations, findStations, findFires, findRecreationAreas, findEnterableBuildings } from './gridFinders';
 import { drawPedestrians as drawPedestriansUtil } from './drawPedestrians';
@@ -844,7 +844,8 @@ export function useVehicleSystems(
     }
     
     // Scale pedestrian count with city size (road tiles), with a reasonable cap
-    const maxPedestrians = Math.min(PEDESTRIAN_MAX_COUNT, Math.max(150, roadTileCount * 3));
+    const targetPedestrians = roadTileCount * PEDESTRIAN_ROAD_TILE_DENSITY;
+    const maxPedestrians = Math.min(PEDESTRIAN_MAX_COUNT, Math.max(150, targetPedestrians));
     pedestrianSpawnTimerRef.current -= delta;
     
     if (pedestriansRef.current.length < maxPedestrians && pedestrianSpawnTimerRef.current <= 0) {


### PR DESCRIPTION
Reduce pedestrian density per road tile to prevent overcrowding in larger cities.

This change scales pedestrian density from a dedicated constant, resulting in approximately 20% fewer walkers per road tile before hitting the global cap. This maintains liveliness in early cities (due to the 150-person floor) while reining in large surges in downtown areas.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dac7666-a214-4c1a-ae4e-c599997c3d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dac7666-a214-4c1a-ae4e-c599997c3d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

