### PR TITLE
Show example sprites on home screen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -298,12 +298,10 @@ export default function HomePage() {
           IsoCity
         </h1>
         
-        {/* Sprite Gallery - hide if there are saved cities to save space */}
-        {savedCities.length === 0 && (
-          <div className="mb-6">
-            <SpriteGallery count={9} cols={3} />
-          </div>
-        )}
+        {/* Sprite Gallery - keep visible even when saves exist */}
+        <div className="mb-6">
+          <SpriteGallery count={9} cols={3} />
+        </div>
         
         {/* Buttons */}
         <div className="flex flex-col gap-3 w-full max-w-xs">


### PR DESCRIPTION
Always show the sprite gallery on the mobile home screen to keep example sprites visible even when saved games exist.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb8e2fd1-8657-4afb-8822-556054855af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb8e2fd1-8657-4afb-8822-556054855af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

