### PR TITLE
Fix image generation for social media

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,10 +30,11 @@ export const metadata: Metadata = {
     type: 'website',
     images: [
       {
-        url: '/og-image.png',
+        url: '/opengraph-image',
         width: 1179,
         height: 1406,
         type: 'image/png',
+        alt: 'ISOCITY - Isometric city builder game screenshot',
       },
     ],
   },
@@ -43,9 +44,10 @@ export const metadata: Metadata = {
     description: 'A richly detailed isometric city builder. Build your metropolis and manage resources with cars, planes, helicopters, boats, trains, citizens, and more.',
     images: [
       {
-        url: '/og-image.png',
+        url: '/opengraph-image',
         width: 1179,
         height: 1406,
+        alt: 'ISOCITY - Isometric city builder game screenshot',
       },
     ],
   },

--- a/src/app/opengraph-image/route.ts
+++ b/src/app/opengraph-image/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
 
 // Static list of game screenshots
 const GAME_IMAGES = [
@@ -14,12 +16,50 @@ const GAME_IMAGES = [
 ];
 
 export async function GET(request: NextRequest) {
-  // Pick a random image
-  const randomFile = GAME_IMAGES[Math.floor(Math.random() * GAME_IMAGES.length)];
-  
-  // Get the base URL from the request
-  const baseUrl = new URL(request.url).origin;
-  
-  // Redirect to the static image
-  return NextResponse.redirect(`${baseUrl}/games/${randomFile}`, { status: 302 });
+  try {
+    // Pick a random image (or use a query param for consistent previews)
+    const url = new URL(request.url);
+    const imageIndex = url.searchParams.get('i');
+    
+    let selectedImage: string;
+    if (imageIndex !== null && !isNaN(parseInt(imageIndex))) {
+      const idx = parseInt(imageIndex) % GAME_IMAGES.length;
+      selectedImage = GAME_IMAGES[idx];
+    } else {
+      selectedImage = GAME_IMAGES[Math.floor(Math.random() * GAME_IMAGES.length)];
+    }
+    
+    // Read the image file directly from the public folder
+    const imagePath = path.join(process.cwd(), 'public', 'games', selectedImage);
+    const imageBuffer = await readFile(imagePath);
+    
+    // Return the image directly with proper headers for social media crawlers
+    return new NextResponse(imageBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/png',
+        'Content-Length': imageBuffer.length.toString(),
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Error serving OG image:', error);
+    
+    // Fallback to the static og-image.png
+    try {
+      const fallbackPath = path.join(process.cwd(), 'public', 'og-image.png');
+      const fallbackBuffer = await readFile(fallbackPath);
+      
+      return new NextResponse(fallbackBuffer, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/png',
+          'Content-Length': fallbackBuffer.length.toString(),
+          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+        },
+      });
+    } catch {
+      return new NextResponse('Image not found', { status: 404 });
+    }
+  }
 }


### PR DESCRIPTION
Serve Open Graph images directly from `/opengraph-image` route and update metadata to fix social media previews.

Social media crawlers (e.g., Facebook, Twitter) often fail to follow 302 redirects, preventing them from fetching and displaying the Open Graph image. This change ensures the image content is served directly with a 200 OK status.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fee9851-41cf-466c-ab6a-4255f47dc32f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fee9851-41cf-466c-ab6a-4255f47dc32f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

