### PR TITLE
Remove city generator button

### DIFF
--- a/src/components/game/panels/SettingsPanel.tsx
+++ b/src/components/game/panels/SettingsPanel.tsx
@@ -40,7 +40,7 @@ function formatMoney(money: number): string {
 }
 
 export function SettingsPanel() {
-  const { state, setActivePanel, setDisastersEnabled, newGame, loadState, exportState, generateRandomCity, currentSpritePack, availableSpritePacks, setSpritePack, dayNightMode, setDayNightMode, getSavedCityInfo, restoreSavedCity, clearSavedCity, savedCities, saveCity, loadSavedCity, deleteSavedCity, renameSavedCity } = useGame();
+  const { state, setActivePanel, setDisastersEnabled, newGame, loadState, exportState, currentSpritePack, availableSpritePacks, setSpritePack, dayNightMode, setDayNightMode, getSavedCityInfo, restoreSavedCity, clearSavedCity, savedCities, saveCity, loadSavedCity, deleteSavedCity, renameSavedCity } = useGame();
   const { disastersEnabled, cityName, gridSize, id: currentCityId } = state;
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -567,17 +567,6 @@ export function SettingsPanel() {
             >
               Load Example State 9
             </Button>
-            <Button
-              variant="default"
-              className="w-full mt-4"
-              onClick={() => {
-                generateRandomCity();
-                setActivePanel('none');
-              }}
-            >
-              Generate Random City
-            </Button>
-            
             <div className="mt-4 pt-4 border-t border-border">
               <Label>Day/Night Mode</Label>
               <p className="text-muted-foreground text-xs mb-2">Override the time-of-day appearance without affecting time progression</p>


### PR DESCRIPTION
Remove the random city generator button from the settings panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3956ee5-4860-40f8-b2ce-1e858cdbc70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3956ee5-4860-40f8-b2ce-1e858cdbc70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

