### PR TITLE
Add service radius overlays with building highlights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Commands
+- `npm run dev` - Start development server
+- `npm run build` - Production build (also type-checks)
+- `npm run lint` - Run ESLint
+- No test framework configured
+
+## Architecture
+Next.js 16 + React 19 isometric city-builder game with canvas rendering.
+- `src/app/` - Next.js App Router pages
+- `src/components/` - React components (Game.tsx is main entry, `game/` for game UI, `buildings/` for building renderers, `ui/` for shadcn components)
+- `src/context/` - React context (GameContext for global state)
+- `src/hooks/` - Custom hooks (useMobile, useCheatCodes)
+- `src/lib/` - Utilities (simulation.ts for game logic, renderConfig.ts for canvas)
+- `src/types/game.ts` - TypeScript types
+
+## Code Style
+- TypeScript with strict mode; use `@/*` path alias for imports
+- React functional components with 'use client' directive
+- shadcn/ui + Radix UI + Tailwind CSS for styling
+- ESLint with eslint-config-next

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2277,6 +2278,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2287,6 +2289,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2337,6 +2340,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2874,6 +2878,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3301,6 +3306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3959,6 +3965,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4144,6 +4151,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5367,6 +5375,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5699,6 +5708,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
       "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",
@@ -6103,6 +6113,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6297,6 +6308,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6319,6 +6331,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7068,6 +7081,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7196,6 +7210,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7363,6 +7378,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7713,6 +7729,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -842,7 +842,8 @@ export function createInitialGameState(size: number = DEFAULT_GRID_SIZE, cityNam
 }
 
 // Service building configuration - defined once, reused across calls
-const SERVICE_CONFIG = {
+// Exported so overlay rendering can access radii
+export const SERVICE_CONFIG = {
   police_station: { range: 13, rangeSquared: 169, type: 'police' as const },
   fire_station: { range: 18, rangeSquared: 324, type: 'fire' as const },
   hospital: { range: 12, rangeSquared: 144, type: 'health' as const },


### PR DESCRIPTION
## Summary

This PR improves the service overlay system to make it easier to see where service buildings are located and their coverage areas.

## Changes

- Simplified overlay coloring: buildings without coverage show a red warning tint, covered buildings and empty tiles show no overlay
- Added isometric ellipse radius circles around service buildings (fire, police, health, education, power, water)
- Added diamond highlight and center dot on service buildings when their overlay is active
- Skip abandoned buildings in radius drawing (matches simulation behavior)

## Technical Details

- Exported SERVICE_CONFIG from simulation.ts so overlay rendering can access service radii
- Added explicit OVERLAY_CIRCLE_FILL_COLORS for robust fill styling (instead of brittle string replacement)
- Added OVERLAY_TO_BUILDING_TYPES mapping for overlay-to-service-building lookup

## Demo

https://github.com/user-attachments/assets/dce9e456-7c8b-4cd4-97d2-d63047b39eb8

## Files Changed

- src/lib/simulation.ts - Export SERVICE_CONFIG
- src/components/game/overlays.ts - Simplified overlay logic, added color mappings
- src/components/game/CanvasIsometricGrid.tsx - Radius circle and highlight drawing
- AGENTS.md - New file with build commands and architecture notes

## Amp Thread
[T-019b4c0d-f287-72ce-b4f9-b6630332ac69](https://ampcode.com/threads/T-019b4c0d-f287-72ce-b4f9-b6630332ac69)