### PR TITLE
feat: require road connection for service buildings

### DIFF
--- a/src/components/game/CanvasIsometricGrid.tsx
+++ b/src/components/game/CanvasIsometricGrid.tsx
@@ -60,7 +60,7 @@ import {
   OVERLAY_CIRCLE_FILL_COLORS,
   OVERLAY_HIGHLIGHT_COLORS,
 } from '@/components/game/overlays';
-import { SERVICE_CONFIG, isServiceBuildingConnectedToRoad } from '@/lib/simulation';
+import { SERVICE_CONFIG, hasRequiredRoadAccess } from '@/lib/simulation';
 import { drawPlaceholderBuilding } from '@/components/game/placeholders';
 import { loadImage, loadSpriteImage, onImageLoaded, getCachedImage } from '@/components/game/imageLoader';
 import { TileInfoPanel } from '@/components/game/panels';
@@ -2924,11 +2924,6 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
           const circleFillColor = OVERLAY_CIRCLE_FILL_COLORS[overlayMode];
           const highlightColor = OVERLAY_HIGHLIGHT_COLORS[overlayMode];
           
-          // Service buildings that require road connection (not utilities like power/water)
-          const SERVICE_BUILDINGS_REQUIRING_ROAD = new Set([
-            'police_station', 'fire_station', 'hospital', 'school', 'university'
-          ]);
-          
           // Find all service buildings of this type and draw their radii
           for (let y = 0; y < gridSize; y++) {
             for (let x = 0; x < gridSize; x++) {
@@ -2947,9 +2942,8 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
               
               const range = config.range;
               
-              // Check if this service building requires road connection and if it's connected
-              const requiresRoad = SERVICE_BUILDINGS_REQUIRING_ROAD.has(tile.building.type);
-              const isConnected = !requiresRoad || isServiceBuildingConnectedToRoad(grid, gridSize, x, y);
+              // Check if this service building has required road access
+              const isConnected = hasRequiredRoadAccess(grid, gridSize, x, y, tile.building.type);
               
               // NOTE: For multi-tile service buildings (e.g. 2x2 hospital, 3x3 university),
               // coverage is computed from the building's anchor tile (top-left of footprint)

--- a/src/components/game/panels/TileInfoPanel.tsx
+++ b/src/components/game/panels/TileInfoPanel.tsx
@@ -7,12 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { CloseIcon } from '@/components/ui/Icons';
-import { isServiceBuildingConnectedToRoad } from '@/lib/simulation';
-
-// Service buildings that require road connection
-const SERVICE_BUILDINGS_REQUIRING_ROAD = new Set([
-  'police_station', 'fire_station', 'hospital', 'school', 'university'
-]);
+import { SERVICE_CONFIG, hasRequiredRoadAccess } from '@/lib/simulation';
 
 interface TileInfoPanelProps {
   tile: Tile;
@@ -40,11 +35,10 @@ export function TileInfoPanel({
 }: TileInfoPanelProps) {
   const { x, y } = tile;
   
-  // Check if this is a service building that requires road connection
-  const requiresRoadConnection = SERVICE_BUILDINGS_REQUIRING_ROAD.has(tile.building.type);
-  const hasRoadConnection = requiresRoadConnection 
-    ? isServiceBuildingConnectedToRoad(grid, gridSize, x, y) 
-    : true;
+  // Check if this building requires road connection
+  const config = SERVICE_CONFIG[tile.building.type as keyof typeof SERVICE_CONFIG];
+  const requiresRoadConnection = config?.requiresRoad === true;
+  const hasRoadConnection = hasRequiredRoadAccess(grid, gridSize, x, y, tile.building.type);
   
   return (
     <Card 


### PR DESCRIPTION
## Issue

Service buildings were providing coverage regardless of road connectivity, allowing players to "cheat" by placing them in isolated areas without proper infrastructure. 

## Solution

Service buildings now require road access (adjacent road tile) to provide coverage.

Service buildings without road access no longer contribute to police, fire, health, or education coverage.
Utilities (power plants, water towers) are exempt since they provide infrastructure rather than requiring it.

<img width="2484" height="1026" alt="CleanShot 2025-12-25 at 04 39 21@2x" src="https://github.com/user-attachments/assets/a4adbb51-6c45-4d38-8eba-b6b444f0ee6d" />

<img width="2456" height="1042" alt="CleanShot 2025-12-25 at 04 39 32@2x" src="https://github.com/user-attachments/assets/a462c861-af9f-4837-b1d7-6350f92efbe7" />

## Changes

### Logic
- Added `requiresRoad` property to `SERVICE_CONFIG` for explicit road requirement flags
- Added `hasRequiredRoadAccess()` function that checks both the building's road requirement and actual road connectivity
- Modified `calculateServiceCoverage()` to skip disconnected service buildings when calculating coverage

### Gameplay

When selecting a building
- Added "Road Access" status badge
- Green "Connected" badge when building has road access
- Red "No Road" badge when disconnected
- Only shown for service buildings that require roads

## Testing
- Place service building without roads → should not provide coverage
- Place service building adjacent to road → should provide coverage
- Connect road to previously disconnected service → should start providing coverage
- Verify utilities still work without road connection