### PR TITLE
fix: update z-index of Sidebar component for improved layering

### DIFF
--- a/src/components/game/Sidebar.tsx
+++ b/src/components/game/Sidebar.tsx
@@ -337,7 +337,7 @@ export const Sidebar = React.memo(function Sidebar({ onExit }: { onExit?: () => 
   ], []);
   
   return (
-    <div className="w-56 bg-sidebar border-r border-sidebar-border flex flex-col h-full relative z-40">
+    <div className="w-56 bg-sidebar border-r border-sidebar-border flex flex-col h-full relative z-[60]">
       <div className="px-4 py-4 border-b border-sidebar-border">
         <div className="flex items-center justify-between">
           <span className="text-sidebar-foreground font-bold tracking-tight">ISOCITY</span>


### PR DESCRIPTION
The left-hand menu has some buildings that are in a z-order that's below the view overlay. This updates the z-ordering so that you can access all of the buildings.

Before:
<img width="584" height="264" alt="Screenshot 2025-12-25 at 8 36 49 AM" src="https://github.com/user-attachments/assets/f277c84f-3ec7-4bec-9165-2199eb1c9bde" />

After:
<img width="481" height="274" alt="Screenshot 2025-12-25 at 4 38 39 PM" src="https://github.com/user-attachments/assets/d2c94487-c6a0-4c81-bb94-e07283996c5a" />
