### PR TITLE
Tools sidebar city expansion

### DIFF
--- a/src/components/game/Sidebar.tsx
+++ b/src/components/game/Sidebar.tsx
@@ -12,6 +12,7 @@ const CATEGORY_LABELS: Record<string, unknown> = {
   tools: msg('Tools'),
   zones: msg('Zones'),
   zoning: msg('Zoning'),
+  expandCity: msg('Expand City'),
   services: msg('Services'),
   parks: msg('Parks'),
   sports: msg('Sports'),
@@ -250,6 +251,173 @@ const HoverSubmenu = React.memo(function HoverSubmenu({
   );
 });
 
+// Action Submenu Component for executing actions (like expand/shrink city)
+const ActionSubmenu = React.memo(function ActionSubmenu({
+  label,
+  actions,
+}: {
+  label: unknown;
+  actions: { key: string; name: unknown; description: string; onClick: () => void }[];
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0, buttonHeight: 0, openUpward: false });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const submenuRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const lastMousePos = useRef<{ x: number; y: number } | null>(null);
+  const m = useMessages();
+  
+  const SUBMENU_GAP = 12;
+  const SUBMENU_MAX_HEIGHT = 220;
+  
+  const clearCloseTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+  
+  const handleMouseEnter = useCallback(() => {
+    clearCloseTimeout();
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const spaceBelow = viewportHeight - rect.top;
+      const openUpward = spaceBelow < SUBMENU_MAX_HEIGHT && rect.top > SUBMENU_MAX_HEIGHT;
+      
+      setMenuPosition({
+        top: openUpward ? rect.bottom : rect.top,
+        left: rect.right + SUBMENU_GAP,
+        buttonHeight: rect.height,
+        openUpward,
+      });
+    }
+    setIsOpen(true);
+  }, [clearCloseTimeout]);
+  
+  const isMovingTowardSubmenu = useCallback((e: React.MouseEvent) => {
+    if (!lastMousePos.current || !submenuRef.current) return false;
+    
+    const submenuRect = submenuRef.current.getBoundingClientRect();
+    const currentX = e.clientX;
+    const currentY = e.clientY;
+    const lastX = lastMousePos.current.x;
+    
+    const movingRight = currentX > lastX;
+    const padding = 50;
+    const withinVerticalBounds = 
+      currentY >= submenuRect.top - padding && 
+      currentY <= submenuRect.bottom + padding;
+    
+    return movingRight && withinVerticalBounds;
+  }, []);
+  
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    lastMousePos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+  
+  const handleMouseLeave = useCallback((e: React.MouseEvent) => {
+    const delay = isMovingTowardSubmenu(e) ? 300 : 100;
+    clearCloseTimeout();
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, delay);
+  }, [clearCloseTimeout, isMovingTowardSubmenu]);
+  
+  const handleSubmenuEnter = useCallback(() => {
+    clearCloseTimeout();
+  }, [clearCloseTimeout]);
+  
+  const handleSubmenuLeave = useCallback(() => {
+    clearCloseTimeout();
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 100);
+  }, [clearCloseTimeout]);
+  
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+  
+  return (
+    <div 
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Button
+        ref={buttonRef}
+        variant="ghost"
+        className={`w-full justify-between gap-2 px-3 py-2.5 h-auto text-sm group transition-all duration-200 ${isOpen ? 'bg-muted/80' : ''}`}
+      >
+        <span className="font-medium">{m(label as Parameters<typeof m>[0])}</span>
+        <svg 
+          className={`w-4 h-4 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}
+          fill="none" 
+          viewBox="0 0 24 24" 
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </Button>
+      
+      {isOpen && (
+        <div
+          className="fixed"
+          style={{
+            top: `${menuPosition.top}px`,
+            left: `${menuPosition.left - SUBMENU_GAP}px`,
+            width: `${SUBMENU_GAP + 8}px`,
+            height: `${Math.max(menuPosition.buttonHeight, 200)}px`,
+            zIndex: 9998,
+          }}
+          onMouseEnter={handleSubmenuEnter}
+          onMouseLeave={handleSubmenuLeave}
+        />
+      )}
+      
+      {isOpen && (
+        <div 
+          ref={submenuRef}
+          className="fixed w-52 bg-sidebar backdrop-blur-sm border border-sidebar-border rounded-md shadow-xl overflow-hidden animate-submenu-in"
+          style={{ 
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(96, 165, 250, 0.1)',
+            zIndex: 9999,
+            ...(menuPosition.openUpward 
+              ? { bottom: `${window.innerHeight - menuPosition.top}px` }
+              : { top: `${menuPosition.top}px` }),
+            left: `${menuPosition.left}px`,
+          }}
+          onMouseEnter={handleSubmenuEnter}
+          onMouseLeave={handleSubmenuLeave}
+        >
+          <div className="px-3 py-2 border-b border-sidebar-border/50 bg-muted/30">
+            <span className="text-[10px] font-bold tracking-widest text-muted-foreground uppercase">{m(label as Parameters<typeof m>[0])}</span>
+          </div>
+          <div className="p-1.5 flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+            {actions.map(action => (
+              <Button
+                key={action.key}
+                onClick={action.onClick}
+                variant="ghost"
+                className="w-full justify-start gap-2 px-3 py-2 h-auto text-sm transition-all duration-150 hover:bg-muted/60"
+                title={action.description}
+              >
+                <span className="flex-1 text-left truncate">{m(action.name as Parameters<typeof m>[0])}</span>
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
 // Exit confirmation dialog component
 function ExitDialog({ 
   open, 
@@ -293,7 +461,7 @@ function ExitDialog({
 
 // Memoized Sidebar Component
 export const Sidebar = React.memo(function Sidebar({ onExit }: { onExit?: () => void }) {
-  const { state, setTool, setActivePanel, saveCity } = useGame();
+  const { state, setTool, setActivePanel, saveCity, expandCity, shrinkCity } = useGame();
   const { selectedTool, stats, activePanel } = state;
   const [showExitDialog, setShowExitDialog] = useState(false);
   const m = useMessages();
@@ -321,6 +489,22 @@ export const Sidebar = React.memo(function Sidebar({ onExit }: { onExit?: () => 
     label: CATEGORY_LABELS.zoning,
     tools: ['zone_dezone', 'zone_water', 'zone_land'] as Tool[]
   }), []);
+  
+  // Expand City submenu (shown under TOOLS section)
+  const expandCityActions = useMemo(() => [
+    {
+      key: 'expand_city',
+      name: TOOL_INFO['expand_city'].name,
+      description: 'Add 15 tiles to each edge of the city',
+      onClick: expandCity,
+    },
+    {
+      key: 'shrink_city',
+      name: TOOL_INFO['shrink_city'].name,
+      description: 'Remove 15 tiles from each edge of the city',
+      onClick: shrinkCity,
+    },
+  ], [expandCity, shrinkCity]);
   
   // Submenu categories (hover to expand) - includes all new assets from main
   const submenuCategories = useMemo(() => [
@@ -439,6 +623,14 @@ export const Sidebar = React.memo(function Sidebar({ onExit }: { onExit?: () => 
                   </Button>
                 );
               })}
+              {/* Expand City submenu - appears after TOOLS category */}
+              {category === 'TOOLS' && (
+                <ActionSubmenu
+                  key="expandCity"
+                  label={CATEGORY_LABELS.expandCity}
+                  actions={expandCityActions}
+                />
+              )}
               {/* Zoning submenu - appears after ZONES category */}
               {category === 'ZONES' && (
                 <HoverSubmenu

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -86,6 +86,8 @@ export type Tool =
   | 'road'
   | 'rail'
   | 'subway'
+  | 'expand_city'
+  | 'shrink_city'
   | 'tree'
   | 'zone_residential'
   | 'zone_commercial'
@@ -153,6 +155,8 @@ export const TOOL_INFO: Record<Tool, ToolInfo> = {
   road: { name: msg('Road'), cost: 25, description: msg('Connect your city') },
   rail: { name: msg('Rail'), cost: 40, description: msg('Build railway tracks') },
   subway: { name: msg('Subway'), cost: 50, description: msg('Underground transit') },
+  expand_city: { name: msg('Expand City'), cost: 0, description: msg('Add 15 tiles to each edge') },
+  shrink_city: { name: msg('Shrink City'), cost: 0, description: msg('Remove 15 tiles from each edge') },
   tree: { name: msg('Tree'), cost: 15, description: msg('Plant trees to improve environment') },
   zone_residential: { name: msg('Residential'), cost: 50, description: msg('Zone for housing') },
   zone_commercial: { name: msg('Commercial'), cost: 50, description: msg('Zone for shops and offices') },


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-6385579e-e764-4b67-8af0-3e805f8787e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6385579e-e764-4b67-8af0-3e805f8787e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces city-size management actions accessible from the sidebar.
> 
> - Adds `ActionSubmenu` flyout for actions and integrates it after `TOOLS` with `expandCityActions`
> - Wires `expandCity`/`shrinkCity` from `useGame` in `Sidebar` and triggers them via submenu buttons
> - Extends `Tool` with `expand_city`/`shrink_city` and updates `TOOL_INFO` with labels/descriptions (cost 0)
> - Adds translatable `CATEGORY_LABELS.expandCity` for the submenu label
> - Retains existing zoning/buildings submenus; no changes to game logic shown beyond invoking provided actions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19f5bb2f7557407a397f73dba8a4b97eccaeddea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->