### PR TITLE
Revert "Big cities mobile performance"

### DIFF
--- a/src/components/game/CanvasIsometricGrid.tsx
+++ b/src/components/game/CanvasIsometricGrid.tsx
@@ -100,11 +100,8 @@ import {
   drawTrains,
   MIN_RAIL_TILES_FOR_TRAINS,
   MAX_TRAINS,
-  MAX_TRAINS_MOBILE,
   TRAIN_SPAWN_INTERVAL,
-  TRAIN_SPAWN_INTERVAL_MOBILE,
   TRAINS_PER_RAIL_TILES,
-  TRAINS_PER_RAIL_TILES_MOBILE,
 } from '@/components/game/trainSystem';
 import { Train } from '@/components/game/types';
 import { useLightingSystem } from '@/components/game/lightingSystem';
@@ -779,23 +776,20 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
       return;
     }
 
-    // Calculate max trains based on rail network size - lower limits on mobile
-    const maxTrainsLimit = isMobile ? MAX_TRAINS_MOBILE : MAX_TRAINS;
-    const trainsPerTile = isMobile ? TRAINS_PER_RAIL_TILES_MOBILE : TRAINS_PER_RAIL_TILES;
-    const maxTrains = Math.min(maxTrainsLimit, Math.ceil(railTileCount / trainsPerTile));
+    // Calculate max trains based on rail network size
+    const maxTrains = Math.min(MAX_TRAINS, Math.ceil(railTileCount / TRAINS_PER_RAIL_TILES));
     
     // Speed multiplier based on game speed
     const speedMultiplier = currentSpeed === 1 ? 1 : currentSpeed === 2 ? 2 : 3;
 
-    // Spawn timer - slower on mobile
-    const spawnInterval = isMobile ? TRAIN_SPAWN_INTERVAL_MOBILE : TRAIN_SPAWN_INTERVAL;
+    // Spawn timer
     trainSpawnTimerRef.current -= delta;
     if (trainsRef.current.length < maxTrains && trainSpawnTimerRef.current <= 0) {
       const newTrain = spawnTrain(currentGrid, currentGridSize, trainIdRef);
       if (newTrain) {
         trainsRef.current.push(newTrain);
       }
-      trainSpawnTimerRef.current = spawnInterval;
+      trainSpawnTimerRef.current = TRAIN_SPAWN_INTERVAL;
     }
 
     // Update existing trains (pass all trains for collision detection)
@@ -2379,11 +2373,7 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
       lastTime = time;
       lastRenderTime = time;
       
-      // PERF: Skip ALL vehicle/entity updates during mobile panning/zooming (not just drawing)
-      // This provides a massive performance boost for big cities on mobile
-      const skipMobileUpdates = isMobile && (isPanningRef.current || isPinchZoomingRef.current);
-      
-      if (delta > 0 && !skipMobileUpdates) {
+      if (delta > 0) {
         updateCars(delta);
         spawnCrimeIncidents(delta); // Spawn new crime incidents
         updateCrimeIncidents(delta); // Update/decay crime incidents

--- a/src/components/game/bargeSystem.ts
+++ b/src/components/game/bargeSystem.ts
@@ -6,7 +6,6 @@ import {
   BARGE_SPEED_MIN,
   BARGE_SPEED_MAX,
   MAX_BARGES,
-  MAX_BARGES_MOBILE,
   BARGE_SPAWN_INTERVAL_MIN,
   BARGE_SPAWN_INTERVAL_MAX,
   BARGE_DOCK_TIME_MIN,
@@ -96,10 +95,9 @@ export function useBargeSystem(
     // Speed multiplier based on game speed
     const speedMultiplier = currentSpeed === 1 ? 1 : currentSpeed === 2 ? 1.5 : 2;
 
-    // Spawn timer - use lower limit on mobile
-    const maxBarges = isMobile ? MAX_BARGES_MOBILE : MAX_BARGES;
+    // Spawn timer
     bargeSpawnTimerRef.current -= delta;
-    if (bargesRef.current.length < maxBarges && bargeSpawnTimerRef.current <= 0) {
+    if (bargesRef.current.length < MAX_BARGES && bargeSpawnTimerRef.current <= 0) {
       // Pick a random spawn point on ocean edge
       const spawnPoint = spawnPoints[Math.floor(Math.random() * spawnPoints.length)];
       

--- a/src/components/game/boatSystem.ts
+++ b/src/components/game/boatSystem.ts
@@ -5,9 +5,7 @@ import {
   BOAT_MIN_ZOOM,
   WAKE_MIN_ZOOM_MOBILE,
   BOATS_PER_DOCK,
-  BOATS_PER_DOCK_MOBILE,
   MAX_BOATS,
-  MAX_BOATS_MOBILE,
   WAKE_MAX_AGE,
   WAKE_SPAWN_INTERVAL,
   BOAT_MIN_ZOOM_FAR,
@@ -82,10 +80,8 @@ export function useBoatSystem(
       return;
     }
 
-    // Calculate max boats based on number of docks - lower on mobile for performance
-    const boatsPerDock = isMobile ? BOATS_PER_DOCK_MOBILE : BOATS_PER_DOCK;
-    const maxBoatsLimit = isMobile ? MAX_BOATS_MOBILE : MAX_BOATS;
-    const maxBoats = Math.min(maxBoatsLimit, Math.floor(docks.length * boatsPerDock));
+    // Calculate max boats based on number of docks
+    const maxBoats = Math.min(MAX_BOATS, Math.floor(docks.length * BOATS_PER_DOCK));
     
     // Speed multiplier based on game speed
     const speedMultiplier = currentSpeed === 1 ? 1 : currentSpeed === 2 ? 1.5 : 2;

--- a/src/components/game/constants.ts
+++ b/src/components/game/constants.ts
@@ -34,13 +34,9 @@ export const MAX_BEACH_MATS_PER_EDGE = 2;           // Max mats per beach edge
 
 // Pedestrian performance limits
 export const PEDESTRIAN_MAX_COUNT = 560;            // Maximum pedestrians (hard cap) - reduced ~30%
-export const PEDESTRIAN_MAX_COUNT_MOBILE = 80;      // Mobile: much lower for performance
 export const PEDESTRIAN_ROAD_TILE_DENSITY = 1.7;    // Target pedestrians per road tile - reduced ~30%
-export const PEDESTRIAN_ROAD_TILE_DENSITY_MOBILE = 0.5; // Mobile: lower density
 export const PEDESTRIAN_SPAWN_BATCH_SIZE = 25;      // How many to try spawning at once
-export const PEDESTRIAN_SPAWN_BATCH_SIZE_MOBILE = 5; // Mobile: smaller batches
 export const PEDESTRIAN_SPAWN_INTERVAL = 0.03;      // Seconds between spawn batches
-export const PEDESTRIAN_SPAWN_INTERVAL_MOBILE = 0.15; // Mobile: slower spawning
 export const PEDESTRIAN_UPDATE_SKIP_DISTANCE = 30;  // Skip detailed updates for pedestrians this far from view
 
 // Zoom limits for camera
@@ -135,7 +131,6 @@ export const SEAPLANE_MIN_POPULATION = 3000; // Minimum population for seaplanes
 export const SEAPLANE_MIN_BAY_SIZE = 12; // Minimum water tiles for a bay to support seaplanes
 export const SEAPLANE_COLORS = ['#ffffff', '#1e40af', '#dc2626', '#f97316', '#059669']; // Seaplane liveries
 export const MAX_SEAPLANES = 25; // Maximum seaplanes in the city
-export const MAX_SEAPLANES_MOBILE = 5; // Mobile: fewer seaplanes for performance
 export const SEAPLANE_SPAWN_INTERVAL_MIN = 4; // Minimum seconds between spawns
 export const SEAPLANE_SPAWN_INTERVAL_MAX = 10; // Maximum seconds between spawns
 export const SEAPLANE_TAXI_TIME_MIN = 4; // Minimum seconds taxiing on water before takeoff
@@ -166,9 +161,7 @@ export const BOAT_COLORS = ['#ffffff', '#1e3a5f', '#8b4513', '#2f4f4f', '#c41e3a
 export const BOAT_MIN_ZOOM = 0.3; // Minimum zoom level to show boats
 export const WAKE_MIN_ZOOM_MOBILE = 0.45; // Minimum zoom level to show wakes on mobile (matches traffic lights threshold)
 export const BOATS_PER_DOCK = 1.5; // Number of boats per marina/pier
-export const BOATS_PER_DOCK_MOBILE = 0.5; // Mobile: fewer boats per dock
 export const MAX_BOATS = 12; // Maximum total boats in the city
-export const MAX_BOATS_MOBILE = 4; // Mobile: fewer boats for performance
 export const WAKE_MAX_AGE = 2.0; // seconds - how long wake particles last
 export const WAKE_SPAWN_INTERVAL = 0.03; // seconds between wake particles
 
@@ -178,7 +171,6 @@ export const BARGE_MIN_ZOOM = 0.25; // Minimum zoom level to show barges (slight
 export const BARGE_SPEED_MIN = 8; // Minimum speed (pixels/second) - slower than boats
 export const BARGE_SPEED_MAX = 12; // Maximum speed (pixels/second)
 export const MAX_BARGES = 4; // Maximum barges in the city at once
-export const MAX_BARGES_MOBILE = 2; // Mobile: fewer barges for performance
 export const BARGE_SPAWN_INTERVAL_MIN = 8; // Minimum seconds between barge spawns
 export const BARGE_SPAWN_INTERVAL_MAX = 20; // Maximum seconds between barge spawns
 export const BARGE_DOCK_TIME_MIN = 8; // Minimum seconds docked at marina
@@ -272,10 +264,8 @@ export const TRAFFIC_LIGHT_CYCLE = 7.6;            // Full cycle time
 // Train system constants
 export const TRAIN_MIN_ZOOM = 0.35;               // Minimum zoom to show trains (normal)
 export const TRAIN_SPAWN_INTERVAL = 3.0;          // Seconds between train spawn attempts
-export const TRAIN_SPAWN_INTERVAL_MOBILE = 6.0;   // Mobile: slower train spawning
 export const MIN_RAIL_TILES_FOR_TRAINS = 10;      // Minimum rail tiles needed
 export const MAX_TRAINS = 35;                      // Maximum trains in city
-export const MAX_TRAINS_MOBILE = 8;               // Mobile: fewer trains for performance
 
 // Far zoom thresholds - all mobile/animated entities hidden below these levels
 export const HELICOPTER_MIN_ZOOM = 0.3;           // Minimum zoom to show helicopters

--- a/src/components/game/seaplaneSystem.ts
+++ b/src/components/game/seaplaneSystem.ts
@@ -5,7 +5,6 @@ import {
   SEAPLANE_MIN_BAY_SIZE,
   SEAPLANE_COLORS,
   MAX_SEAPLANES,
-  MAX_SEAPLANES_MOBILE,
   SEAPLANE_SPAWN_INTERVAL_MIN,
   SEAPLANE_SPAWN_INTERVAL_MAX,
   SEAPLANE_TAXI_TIME_MIN,
@@ -128,12 +127,10 @@ export function useSeaplaneSystem(
       return;
     }
 
-    // Calculate max seaplanes based on population and bay count - lower on mobile
-    const maxSeaplaneLimit = isMobile ? MAX_SEAPLANES_MOBILE : MAX_SEAPLANES;
-    const minSeaplanes = isMobile ? 1 : 3;
+    // Calculate max seaplanes based on population and bay count
     const populationBased = Math.floor(totalPopulation / 2000);
     const bayBased = Math.floor(bays.length * 5);
-    const maxSeaplanes = Math.min(maxSeaplaneLimit, Math.max(minSeaplanes, Math.min(populationBased, bayBased)));
+    const maxSeaplanes = Math.min(MAX_SEAPLANES, Math.max(3, Math.min(populationBased, bayBased)));
     
     // Speed multiplier based on game speed
     const speedMultiplier = currentSpeed === 1 ? 1 : currentSpeed === 2 ? 1.5 : 2;

--- a/src/components/game/trainSystem.ts
+++ b/src/components/game/trainSystem.ts
@@ -159,15 +159,12 @@ export const MIN_RAIL_TILES_FOR_TRAINS = 6;
 
 /** Maximum trains per rail network size */
 export const TRAINS_PER_RAIL_TILES = 6; // 1 train per 6 rail tiles
-export const TRAINS_PER_RAIL_TILES_MOBILE = 12; // 1 train per 12 rail tiles on mobile
 
 /** Maximum trains in the city */
 export const MAX_TRAINS = 35;
-export const MAX_TRAINS_MOBILE = 8; // Fewer trains on mobile for performance
 
 /** Train spawn interval in seconds */
 export const TRAIN_SPAWN_INTERVAL = 1.5;
-export const TRAIN_SPAWN_INTERVAL_MOBILE = 4.0; // Slower spawning on mobile
 
 /** Station stop duration in seconds */
 export const STATION_STOP_DURATION = 2.0;

--- a/src/components/game/vehicleSystems.ts
+++ b/src/components/game/vehicleSystems.ts
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { Car, CarDirection, EmergencyVehicle, EmergencyVehicleType, Pedestrian, PedestrianDestType, WorldRenderState, TILE_WIDTH, TILE_HEIGHT } from './types';
-import { CAR_COLORS, CAR_MIN_ZOOM, CAR_MIN_ZOOM_MOBILE, PEDESTRIAN_MIN_ZOOM, PEDESTRIAN_MIN_ZOOM_MOBILE, DIRECTION_META, PEDESTRIAN_MAX_COUNT, PEDESTRIAN_MAX_COUNT_MOBILE, PEDESTRIAN_ROAD_TILE_DENSITY, PEDESTRIAN_ROAD_TILE_DENSITY_MOBILE, PEDESTRIAN_SPAWN_BATCH_SIZE, PEDESTRIAN_SPAWN_BATCH_SIZE_MOBILE, PEDESTRIAN_SPAWN_INTERVAL, PEDESTRIAN_SPAWN_INTERVAL_MOBILE, VEHICLE_FAR_ZOOM_THRESHOLD } from './constants';
+import { CAR_COLORS, CAR_MIN_ZOOM, CAR_MIN_ZOOM_MOBILE, PEDESTRIAN_MIN_ZOOM, PEDESTRIAN_MIN_ZOOM_MOBILE, DIRECTION_META, PEDESTRIAN_MAX_COUNT, PEDESTRIAN_ROAD_TILE_DENSITY, PEDESTRIAN_SPAWN_BATCH_SIZE, PEDESTRIAN_SPAWN_INTERVAL, VEHICLE_FAR_ZOOM_THRESHOLD } from './constants';
 import { isRoadTile, getDirectionOptions, pickNextDirection, findPathOnRoads, getDirectionToTile, gridToScreen } from './utils';
 import { findResidentialBuildings, findPedestrianDestinations, findStations, findFires, findRecreationAreas, findEnterableBuildings, SPORTS_TYPES, ACTIVE_RECREATION_TYPES } from './gridFinders';
 import { drawPedestrians as drawPedestriansUtil } from './drawPedestrians';
@@ -755,33 +755,25 @@ export function useVehicleSystems(
       cachedRoadTileCountRef.current = { count: roadTileCount, gridVersion: currentGridVersion };
     }
     
-    // Target ~0.5 cars per road tile on desktop, ~0.15 on mobile (for performance)
+    // Target ~0.5 cars per road tile on desktop, ~0.35 on mobile (for performance)
     // This ensures large maps with more roads get proportionally more cars
-    const carDensity = isMobile ? 0.15 : 0.5;
+    const carDensity = isMobile ? 0.35 : 0.5;
     const targetCars = Math.floor(roadTileCount * carDensity);
-    // Cap at 800 for desktop, 60 for mobile - minimum 10/15 for small cities
-    const maxCars = isMobile 
-      ? Math.min(60, Math.max(10, targetCars))
-      : Math.min(800, Math.max(15, targetCars));
+    // Cap at 800 for performance, minimum 15 for small cities
+    const maxCars = Math.min(800, Math.max(15, targetCars));
     
     carSpawnTimerRef.current -= delta;
     if (carsRef.current.length < maxCars && carSpawnTimerRef.current <= 0) {
       // Spawn cars at a moderate rate - spawn more at once on large maps to catch up faster
-      // Mobile: spawn fewer cars at once and slower intervals
       const deficit = maxCars - carsRef.current.length;
-      const carsToSpawn = isMobile 
-        ? Math.min(1, deficit) 
-        : Math.min(deficit > 50 ? 4 : 2, deficit);
+      const carsToSpawn = Math.min(deficit > 50 ? 4 : 2, deficit);
       let spawnedCount = 0;
       for (let i = 0; i < carsToSpawn; i++) {
         if (spawnRandomCar()) {
           spawnedCount++;
         }
       }
-      // Mobile: slower spawn rate (0.8-1.2s vs 0.3-0.7s on desktop)
-      carSpawnTimerRef.current = spawnedCount > 0 
-        ? (isMobile ? 0.8 + Math.random() * 0.4 : 0.3 + Math.random() * 0.4) 
-        : 0.1;
+      carSpawnTimerRef.current = spawnedCount > 0 ? 0.3 + Math.random() * 0.4 : 0.1;
     }
     
     // Get current traffic light state
@@ -1017,22 +1009,17 @@ export function useVehicleSystems(
     }
     
     // Scale pedestrian count with city size (road tiles), with a reasonable cap
-    // Mobile: use lower density and max count for performance
-    const pedDensity = isMobile ? PEDESTRIAN_ROAD_TILE_DENSITY_MOBILE : PEDESTRIAN_ROAD_TILE_DENSITY;
-    const pedMaxCount = isMobile ? PEDESTRIAN_MAX_COUNT_MOBILE : PEDESTRIAN_MAX_COUNT;
-    const pedMinCount = isMobile ? 20 : 150;
-    const targetPedestrians = roadTileCount * pedDensity;
-    const maxPedestrians = Math.min(pedMaxCount, Math.max(pedMinCount, targetPedestrians));
+    const targetPedestrians = roadTileCount * PEDESTRIAN_ROAD_TILE_DENSITY;
+    const maxPedestrians = Math.min(PEDESTRIAN_MAX_COUNT, Math.max(150, targetPedestrians));
     pedestrianSpawnTimerRef.current -= delta;
     
     if (pedestriansRef.current.length < maxPedestrians && pedestrianSpawnTimerRef.current <= 0) {
-      // Spawn pedestrians in batches - smaller batches on mobile
-      const batchSize = isMobile ? PEDESTRIAN_SPAWN_BATCH_SIZE_MOBILE : PEDESTRIAN_SPAWN_BATCH_SIZE;
-      const spawnBatch = Math.min(batchSize, maxPedestrians - pedestriansRef.current.length);
+      // Spawn pedestrians in batches
+      const spawnBatch = Math.min(PEDESTRIAN_SPAWN_BATCH_SIZE, maxPedestrians - pedestriansRef.current.length);
       for (let i = 0; i < spawnBatch; i++) {
         spawnPedestrian();
       }
-      pedestrianSpawnTimerRef.current = isMobile ? PEDESTRIAN_SPAWN_INTERVAL_MOBILE : PEDESTRIAN_SPAWN_INTERVAL;
+      pedestrianSpawnTimerRef.current = PEDESTRIAN_SPAWN_INTERVAL;
     }
     
     // OPTIMIZED: Reuse array instead of spreading


### PR DESCRIPTION
Reverts amilich/isometric-city#175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rolls back mobile-only performance constraints, standardizing counts, spawn rates, and update behavior across platforms.
> 
> - Deletes mobile-specific constants (e.g., `*_MOBILE`, mobile spawn intervals) in `constants.ts`, `trainSystem.ts`, and related systems
> - Unifies spawn/cap calculations in `boatSystem`, `bargeSystem`, `seaplaneSystem`, and train logic in `CanvasIsometricGrid` to use single `MAX_*` and rate values
> - In `vehicleSystems`, increases mobile car density and removes mobile-specific caps/batch sizes; pedestrians now use unified density/caps/intervals
> - Removes mobile-only update skipping during panning/zooming; all entity updates always run
> - In `useMultiplayerSync`, removes `useMobile`, unifies batching (size/flush interval) and sets a fixed 2s state sync throttle
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a43241bf2c0d1e0e2a510d6be1e6ff35f53b83f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->