### PR TITLE
Fire spread mechanic

### DIFF
--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -2214,6 +2214,44 @@ export function simulateTick(state: GameState): GameState {
         }
       }
 
+      // Fire spread to adjacent buildings
+      // Check if any neighboring tile is on fire and spread with a chance reduced by fire coverage
+      if (state.disastersEnabled && !tile.building.onFire &&
+          tile.building.type !== 'grass' && tile.building.type !== 'water' &&
+          tile.building.type !== 'road' && tile.building.type !== 'tree' &&
+          tile.building.type !== 'empty' && tile.building.type !== 'bridge' &&
+          tile.building.type !== 'rail') {
+        // Check 4 adjacent tiles for fires
+        const adjacentOffsets = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+        let adjacentFireCount = 0;
+        
+        for (const [dx, dy] of adjacentOffsets) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < size && ny >= 0 && ny < size) {
+            const neighbor = newGrid[ny][nx];
+            if (neighbor.building.onFire) {
+              adjacentFireCount++;
+            }
+          }
+        }
+        
+        if (adjacentFireCount > 0) {
+          // Base spread chance per adjacent fire: 1.5% per tick
+          // Each additional adjacent fire increases the chance
+          // Fire coverage significantly reduces spread chance
+          const fireCoverage = services.fire[y][x];
+          const coverageReduction = fireCoverage / 100; // 0-1 based on coverage (100% coverage = 1)
+          const baseSpreadChance = 0.015 * adjacentFireCount;
+          const spreadChance = baseSpreadChance * (1 - coverageReduction * 0.9); // Fire coverage can reduce spread by up to 90%
+          
+          if (Math.random() < spreadChance) {
+            tile.building.onFire = true;
+            tile.building.fireProgress = 0;
+          }
+        }
+      }
+
       // Random fire start
       if (state.disastersEnabled && !tile.building.onFire && 
           tile.building.type !== 'grass' && tile.building.type !== 'water' && 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-91de6db3-9b61-4ecc-bfab-e705ec2422d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91de6db3-9b61-4ecc-bfab-e705ec2422d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a simple fire propagation mechanic in `src/lib/simulation.ts` during `simulateTick`.
> 
> - New adjacent-fire check for non-flammable tiles (excludes `grass`, `water`, `road`, `tree`, `empty`, `bridge`, `rail`) with 4-neighbor scan
> - Spread chance: `1.5% * adjacentFireCount`, reduced by up to 90% based on `services.fire` coverage; on spread, sets `onFire` and resets `fireProgress`
> - Integrates between existing fire fighting/consumption logic and the random fire start
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94dee2c75946ce72fd7db96f3859eb596ae9b1a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->