### PR TITLE
Supabase url configuration fix

### DIFF
--- a/src/lib/multiplayer/supabaseProvider.ts
+++ b/src/lib/multiplayer/supabaseProvider.ts
@@ -19,10 +19,13 @@ import {
 import { GameState } from '@/types/game';
 import { msg } from 'gt-next';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-const supabase = createClient(supabaseUrl, supabaseKey);
+// Lazy init: only create client when Supabase is configured
+const supabase = supabaseUrl && supabaseKey 
+  ? createClient(supabaseUrl, supabaseKey) 
+  : null;
 
 // Throttle state saves to avoid excessive database writes
 const STATE_SAVE_INTERVAL = 3000; // Save state every 3 seconds max
@@ -58,6 +61,9 @@ export class MultiplayerProvider {
   private saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: MultiplayerProviderOptions) {
+    if (!supabase) {
+      throw new Error('Multiplayer requires Supabase configuration');
+    }
     this.options = options;
     this.roomCode = options.roomCode;
     this.peerId = generatePlayerId();
@@ -310,7 +316,7 @@ export class MultiplayerProvider {
     }
     
     this.channel.unsubscribe();
-    supabase.removeChannel(this.channel);
+    supabase?.removeChannel(this.channel);
   }
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-d84ea02f-0492-4b3c-8499-40e672a68729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d84ea02f-0492-4b3c-8499-40e672a68729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves resilience when Supabase env vars are absent and prevents runtime crashes.
> 
> - Replace non-null env assertions with conditional init of `supabase`; create client only if both `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` are set
> - Add early-return guards in `database.ts` for `createGameRoom`, `loadGameRoom`, `updateGameRoom`, `roomExists`, and `updatePlayerCount` when `supabase` is not configured
> - In `supabaseProvider.ts`, throw a clear error in `MultiplayerProvider` constructor if Supabase is not configured; use `supabase?.removeChannel` on destroy
> - No functional changes to game logic; primarily configuration-safety and runtime stability adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d036878119ce36e17814fa77de05dfc4c10147c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->