### PR TITLE
Realistic graphics overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^19.2.1",
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.2.1",
+        "simplex-noise": "^4.0.3",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -8441,6 +8442,12 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.2.1",
     "react-device-detect": "^2.2.3",
     "react-dom": "^19.2.1",
+    "simplex-noise": "^4.0.3",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/components/game/shared/isometricRenderer.ts
+++ b/src/components/game/shared/isometricRenderer.ts
@@ -14,9 +14,11 @@ import {
   ZONE_COLORS,
   GREY_TILE_COLORS,
   TileColorScheme,
+  getDiamondCorners,
 } from '../drawing';
 import { loadImage, loadSpriteImage, getCachedImage, onImageLoaded } from '../imageLoader';
 import { WATER_ASSET_PATH } from '../constants';
+import { createNoise2D } from 'simplex-noise';
 
 // Re-export commonly used items
 export {
@@ -37,6 +39,192 @@ export {
   WATER_ASSET_PATH,
 };
 export type { TileColorScheme };
+
+// ============================================================================
+// Realistic terrain helpers (used by RoN)
+// ============================================================================
+
+type NaturalGroundKind = 'grass' | 'dirt' | 'rock';
+
+type NaturalPalette = {
+  base: string;   // primary albedo
+  tint: string;   // subtle color tint used with overlay/soft-light
+  shadow: string; // darker speckle/patch tone
+  stroke: string; // outline
+};
+
+const NATURAL_PALETTES: Record<NaturalGroundKind, NaturalPalette> = {
+  // Temperate grass: muted, slightly olive, less “cartoon green”
+  grass: {
+    base: '#55663b',
+    tint: '#6f7c4a',
+    shadow: '#3f4a2b',
+    stroke: 'rgba(25, 35, 18, 0.45)',
+  },
+  // Dirt: warm, not orange
+  dirt: {
+    base: '#7a6449',
+    tint: '#8a7456',
+    shadow: '#5a4834',
+    stroke: 'rgba(35, 25, 18, 0.45)',
+  },
+  // Rock: neutral grey-brown
+  rock: {
+    base: '#6c6a63',
+    tint: '#7a776e',
+    shadow: '#4c4a44',
+    stroke: 'rgba(20, 20, 20, 0.5)',
+  },
+};
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hash2D(x: number, y: number): number {
+  // Deterministic, stable across sessions
+  let h = Math.imul(x, 0x1f123bb5) ^ Math.imul(y, 0x6a09e667);
+  h ^= h >>> 16;
+  h = Math.imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  h = Math.imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+  return h >>> 0;
+}
+
+const VARIANT_COUNT = 64;
+const noise2D = createNoise2D(mulberry32(133742));
+const naturalTileCache = new Map<string, HTMLCanvasElement>();
+
+function getOrCreateCanvas(w: number, h: number): HTMLCanvasElement {
+  const c = document.createElement('canvas');
+  c.width = Math.max(1, Math.floor(w));
+  c.height = Math.max(1, Math.floor(h));
+  return c;
+}
+
+function buildNaturalTileTexture(kind: NaturalGroundKind, variant: number): HTMLCanvasElement {
+  const palette = NATURAL_PALETTES[kind];
+  const key = `${kind}:${variant}`;
+  const cached = naturalTileCache.get(key);
+  if (cached) return cached;
+
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const canvas = getOrCreateCanvas(w, h);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  // Clip to diamond
+  const corners = getDiamondCorners(0, 0, w, h);
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(corners.top.x, corners.top.y);
+  ctx.lineTo(corners.right.x, corners.right.y);
+  ctx.lineTo(corners.bottom.x, corners.bottom.y);
+  ctx.lineTo(corners.left.x, corners.left.y);
+  ctx.closePath();
+  ctx.clip();
+
+  // Base fill
+  ctx.fillStyle = palette.base;
+  ctx.fillRect(0, 0, w, h);
+
+  // Broad lighting (sun from top-left): subtle, realistic shading
+  const light = ctx.createLinearGradient(w * 0.05, h * 0.05, w * 0.9, h * 0.9);
+  light.addColorStop(0, 'rgba(255,255,255,0.10)');
+  light.addColorStop(0.45, 'rgba(255,255,255,0.00)');
+  light.addColorStop(1, 'rgba(0,0,0,0.14)');
+  ctx.globalCompositeOperation = 'soft-light';
+  ctx.fillStyle = light;
+  ctx.fillRect(0, 0, w, h);
+
+  // Macro variation patches (avoid per-pixel loops; paint a handful of blobs)
+  const rng = mulberry32(0x9e3779b9 ^ variant);
+  const cx = w / 2;
+  const cy = h / 2;
+
+  ctx.globalCompositeOperation = 'overlay';
+  for (let i = 0; i < 14; i++) {
+    const a = rng() * Math.PI * 2;
+    const r = (0.12 + rng() * 0.35) * Math.min(w, h);
+    const px = cx + Math.cos(a) * (w * 0.28) * (0.2 + rng());
+    const py = cy + Math.sin(a) * (h * 0.28) * (0.2 + rng());
+    const sx = r * (0.7 + rng() * 0.9);
+    const sy = r * (0.5 + rng() * 0.9);
+    const phase = noise2D((variant + i) * 0.17, (variant - i) * 0.11);
+
+    ctx.fillStyle = phase > 0 ? `rgba(255,255,255,${0.02 + rng() * 0.03})` : `rgba(0,0,0,${0.03 + rng() * 0.04})`;
+    ctx.beginPath();
+    ctx.ellipse(px, py, sx, sy, rng() * 0.8 - 0.4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // Micro speckle (rocks/grass clumps)
+  ctx.globalCompositeOperation = 'multiply';
+  for (let i = 0; i < 90; i++) {
+    const px = rng() * w;
+    const py = rng() * h;
+    // Keep speckles mostly inside the diamond’s “core” for cleaner edges
+    if (px < w * 0.08 || px > w * 0.92 || py < h * 0.08 || py > h * 0.92) continue;
+    const s = 0.6 + rng() * 1.1;
+    ctx.fillStyle = rng() > 0.55 ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.07)';
+    ctx.fillRect(px, py, s, s);
+  }
+
+  // Gentle tint pass to keep the palette cohesive
+  ctx.globalCompositeOperation = 'color';
+  ctx.globalAlpha = 0.10;
+  ctx.fillStyle = palette.tint;
+  ctx.fillRect(0, 0, w, h);
+
+  // Restore
+  ctx.restore();
+
+  // Cache
+  naturalTileCache.set(key, canvas);
+  return canvas;
+}
+
+/**
+ * Draw a more realistic ground tile (noise-textured + shaded).
+ * Designed for RoN terrain to avoid the saturated “cartoon green” look.
+ */
+export function drawNaturalGroundTile(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  kind: NaturalGroundKind = 'grass',
+  zoom: number = 1
+): void {
+  const variant = hash2D(gridX, gridY) % VARIANT_COUNT;
+  const tex = buildNaturalTileTexture(kind, variant);
+
+  ctx.drawImage(tex, screenX, screenY);
+
+  // Subtle outline only when zoomed in enough (prevents noisy “grid” feel)
+  if (zoom >= 0.65) {
+    const w = TILE_WIDTH;
+    const h = TILE_HEIGHT;
+    ctx.strokeStyle = NATURAL_PALETTES[kind].stroke;
+    ctx.lineWidth = 0.6;
+    ctx.beginPath();
+    ctx.moveTo(screenX + w / 2, screenY);
+    ctx.lineTo(screenX + w, screenY + h / 2);
+    ctx.lineTo(screenX + w / 2, screenY + h);
+    ctx.lineTo(screenX, screenY + h / 2);
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
 
 /**
  * Viewport bounds for culling off-screen tiles
@@ -261,6 +449,107 @@ export function drawWaterTile(
     Math.round(destWidth),
     Math.round(destHeight)
   );
+
+  // Color grade + shoreline shaping (more realistic water)
+  // - Deep water: darker, cooler
+  // - Near shore (missing adjacent water): lighter + subtle foam
+  const shoreMissing = adjacentWater
+    ? (Number(!adjacentWater.north) + Number(!adjacentWater.east) + Number(!adjacentWater.south) + Number(!adjacentWater.west))
+    : 0;
+
+  // Base depth tint
+  ctx.globalCompositeOperation = 'multiply';
+  ctx.globalAlpha = 0.32;
+  const depth = ctx.createLinearGradient(screenX, screenY, screenX + w, screenY + h);
+  depth.addColorStop(0, 'rgba(10, 20, 40, 0.75)');
+  depth.addColorStop(0.55, 'rgba(10, 25, 45, 0.65)');
+  depth.addColorStop(1, 'rgba(6, 12, 26, 0.85)');
+  ctx.fillStyle = depth;
+  ctx.fillRect(screenX, screenY, w, h);
+
+  // Shallow tint near edges that meet land
+  if (shoreMissing > 0 && adjacentWater) {
+    ctx.globalCompositeOperation = 'screen';
+    ctx.globalAlpha = 0.18 + shoreMissing * 0.03;
+    const shallow = 'rgba(70, 190, 190, 0.55)';
+    ctx.fillStyle = shallow;
+
+    // Paint thin strips along missing edges (inside the clipped diamond)
+    const edgeW = Math.max(2, Math.floor(w * 0.08));
+    const edgeH = Math.max(2, Math.floor(h * 0.14));
+
+    // North (top-left edge)
+    if (!adjacentWater.north) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w * 0.02, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.02);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.02 + edgeH);
+      ctx.lineTo(screenX + w * 0.02 + edgeW, screenY + h * 0.5);
+      ctx.closePath();
+      ctx.fill();
+    }
+    // East (top-right edge)
+    if (!adjacentWater.east) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w * 0.5, screenY + h * 0.02);
+      ctx.lineTo(screenX + w * 0.98, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.98 - edgeW, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.02 + edgeH);
+      ctx.closePath();
+      ctx.fill();
+    }
+    // South (bottom-right edge)
+    if (!adjacentWater.south) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w * 0.98, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.98);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.98 - edgeH);
+      ctx.lineTo(screenX + w * 0.98 - edgeW, screenY + h * 0.5);
+      ctx.closePath();
+      ctx.fill();
+    }
+    // West (bottom-left edge)
+    if (!adjacentWater.west) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w * 0.5, screenY + h * 0.98);
+      ctx.lineTo(screenX + w * 0.02, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.02 + edgeW, screenY + h * 0.5);
+      ctx.lineTo(screenX + w * 0.5, screenY + h * 0.98 - edgeH);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    // Foam line (very subtle)
+    ctx.globalCompositeOperation = 'screen';
+    ctx.globalAlpha = 0.22;
+    ctx.strokeStyle = 'rgba(255,255,255,0.55)';
+    ctx.lineWidth = 1;
+    const foamInset = 2;
+    if (!adjacentWater.north) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + foamInset, screenY + h / 2);
+      ctx.lineTo(screenX + w / 2, screenY + foamInset);
+      ctx.stroke();
+    }
+    if (!adjacentWater.east) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w / 2, screenY + foamInset);
+      ctx.lineTo(screenX + w - foamInset, screenY + h / 2);
+      ctx.stroke();
+    }
+    if (!adjacentWater.south) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w - foamInset, screenY + h / 2);
+      ctx.lineTo(screenX + w / 2, screenY + h - foamInset);
+      ctx.stroke();
+    }
+    if (!adjacentWater.west) {
+      ctx.beginPath();
+      ctx.moveTo(screenX + w / 2, screenY + h - foamInset);
+      ctx.lineTo(screenX + foamInset, screenY + h / 2);
+      ctx.stroke();
+    }
+  }
   
   ctx.restore();
 }

--- a/src/games/ron/lib/drawTerrain.ts
+++ b/src/games/ron/lib/drawTerrain.ts
@@ -1,0 +1,153 @@
+/**
+ * Rise of Nations - Terrain/Shoreline rendering helpers.
+ *
+ * Purpose:
+ * - Make coastlines look less “flat/cartoon” by adding shallow-water sand tint
+ *   + subtle foam along edges where water meets land.
+ *
+ * This is RoN-specific (so we don’t accidentally change IsoCity’s sidewalk/beach style).
+ */
+
+import { TILE_WIDTH, TILE_HEIGHT } from '@/components/game/shared';
+import { getDiamondCorners } from '@/components/game/drawing';
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hash2D(x: number, y: number): number {
+  let h = Math.imul(x, 0x1f123bb5) ^ Math.imul(y, 0x6a09e667);
+  h ^= h >>> 16;
+  h = Math.imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  h = Math.imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+  return h >>> 0;
+}
+
+type AdjacentLand = { north: boolean; east: boolean; south: boolean; west: boolean };
+
+/**
+ * Draw a realistic shoreline on a *water* tile (sand shallows + foam).
+ * Call AFTER `drawWaterTile` for best results.
+ */
+export function drawRoNShorelineOnWater(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  adjacentLand: AdjacentLand
+): void {
+  const { north, east, south, west } = adjacentLand;
+  if (!north && !east && !south && !west) return;
+
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const corners = getDiamondCorners(screenX, screenY, w, h);
+
+  // Clip to diamond
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(corners.top.x, corners.top.y);
+  ctx.lineTo(corners.right.x, corners.right.y);
+  ctx.lineTo(corners.bottom.x, corners.bottom.y);
+  ctx.lineTo(corners.left.x, corners.left.y);
+  ctx.closePath();
+  ctx.clip();
+
+  const rng = mulberry32(hash2D(gridX, gridY) ^ 0x4f6c1a2b);
+  const beachWidth = w * 0.14; // wider than IsoCity “sidewalk” to read as shore in RTS camera
+
+  const sandDry = 'rgba(214, 197, 150, 0.55)';
+  const sandWet = 'rgba(168, 152, 110, 0.45)';
+  const foam = 'rgba(255, 255, 255, 0.38)';
+
+  // Helper: draw a sand strip from an edge toward tile center with slight waviness.
+  const drawEdge = (ax: number, ay: number, bx: number, by: number) => {
+    // Inward direction toward center
+    const cx = screenX + w / 2;
+    const cy = screenY + h / 2;
+    const ex = bx - ax;
+    const ey = by - ay;
+    const el = Math.max(1, Math.hypot(ex, ey));
+    const exn = ex / el;
+    const eyn = ey / el;
+
+    // Perp direction (roughly inward), then pick the one that points toward center
+    let px = -eyn;
+    let py = exn;
+    const midx = (ax + bx) * 0.5;
+    const midy = (ay + by) * 0.5;
+    const toCenterX = cx - midx;
+    const toCenterY = cy - midy;
+    if (px * toCenterX + py * toCenterY < 0) {
+      px = -px;
+      py = -py;
+    }
+
+    // Wavy inner edge points (foam boundary)
+    const segments = 5;
+    const ptsOuter: Array<{ x: number; y: number }> = [];
+    const ptsInner: Array<{ x: number; y: number }> = [];
+    for (let i = 0; i <= segments; i++) {
+      const t = i / segments;
+      const ox = ax + ex * t;
+      const oy = ay + ey * t;
+      const wave = (rng() - 0.5) * 2.6;
+      const innerX = ox + px * (beachWidth + wave);
+      const innerY = oy + py * (beachWidth + wave);
+      ptsOuter.push({ x: ox, y: oy });
+      ptsInner.push({ x: innerX, y: innerY });
+    }
+
+    // Sand fill gradient (dry -> wet inward)
+    const grad = ctx.createLinearGradient(midx, midy, midx + px * beachWidth, midy + py * beachWidth);
+    grad.addColorStop(0, sandDry);
+    grad.addColorStop(1, sandWet);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.moveTo(ptsOuter[0].x, ptsOuter[0].y);
+    for (let i = 1; i < ptsOuter.length; i++) ctx.lineTo(ptsOuter[i].x, ptsOuter[i].y);
+    for (let i = ptsInner.length - 1; i >= 0; i--) ctx.lineTo(ptsInner[i].x, ptsInner[i].y);
+    ctx.closePath();
+    ctx.fill();
+
+    // Foam line along inner boundary
+    ctx.strokeStyle = foam;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(ptsInner[0].x, ptsInner[0].y);
+    for (let i = 1; i < ptsInner.length; i++) ctx.lineTo(ptsInner[i].x, ptsInner[i].y);
+    ctx.stroke();
+
+    // Tiny speckles (sand grains)
+    ctx.fillStyle = 'rgba(80, 70, 45, 0.08)';
+    for (let i = 0; i < 14; i++) {
+      const t = rng();
+      const sx = ax + ex * t + px * (rng() * beachWidth);
+      const sy = ay + ey * t + py * (rng() * beachWidth);
+      ctx.fillRect(sx, sy, 0.9, 0.9);
+    }
+  };
+
+  // Map RoN adjacency to diamond edges
+  // In RoN, “north/east/south/west” are the same adjacency used elsewhere:
+  // - north: x-1 (top-left edge) => left->top
+  // - east:  y-1 (top-right edge) => top->right
+  // - south: x+1 (bottom-right edge) => right->bottom
+  // - west:  y+1 (bottom-left edge) => bottom->left
+  if (north) drawEdge(corners.left.x, corners.left.y, corners.top.x, corners.top.y);
+  if (east) drawEdge(corners.top.x, corners.top.y, corners.right.x, corners.right.y);
+  if (south) drawEdge(corners.right.x, corners.right.y, corners.bottom.x, corners.bottom.y);
+  if (west) drawEdge(corners.bottom.x, corners.bottom.y, corners.left.x, corners.left.y);
+
+  ctx.restore();
+}
+

--- a/src/games/ron/lib/renderConfig.ts
+++ b/src/games/ron/lib/renderConfig.ts
@@ -560,12 +560,12 @@ export const TILE_HEIGHT = 38.4; // 64 * 0.6
 
 // Unit sprite colors by player
 export const PLAYER_COLORS = [
-  '#3b82f6', // Blue
-  '#ef4444', // Red
-  '#22c55e', // Green
-  '#f59e0b', // Orange
-  '#8b5cf6', // Purple
-  '#06b6d4', // Cyan
-  '#ec4899', // Pink
-  '#84cc16', // Lime
+  '#2f6fd3', // Blue (slightly muted)
+  '#c9443f', // Red (deeper, less neon)
+  '#2f8a55', // Green (more natural)
+  '#c9802b', // Orange (earthier)
+  '#6c5bd6', // Purple (less saturated)
+  '#1e91a8', // Cyan (darker)
+  '#b04877', // Pink (muted)
+  '#6aa329', // Lime (olive)
 ];


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-5cbc05a0-80fc-4ebb-9758-0c862c6a8a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cbc05a0-80fc-4ebb-9758-0c862c6a8a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades RoN visuals with natural terrain and more realistic water/shorelines.
> 
> - Add `simplex-noise` dependency and implement `drawNaturalGroundTile` in `components/game/shared/isometricRenderer.ts` (palettes, per-tile variants, soft shading, caching)
> - Enhance `drawWaterTile` with depth color grading, shallow-edge tinting, and subtle foam lines
> - New `games/ron/lib/drawTerrain.ts` with `drawRoNShorelineOnWater` to render sand shallows + foam along coastlines
> - Integrate in `games/ron/components/RoNCanvas.tsx`: replace many `drawGroundTile` calls with `drawNaturalGroundTile` (grass/forest/under roads), invoke `drawRoNShorelineOnWater`, switch image smoothing on for terrain then off for sprites, and soften ownership/territory overlays
> - Tweak border rendering (thinner lines, lighter fills) and fix frame delta init
> - Update `PLAYER_COLORS` in `games/ron/lib/renderConfig.ts` to a more muted palette
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74916e4d7a6871fe9316fae732bfe188d41c4c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->