### PR TITLE
Realistic graphics overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^19.2.1",
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.2.1",
+        "simplex-noise": "^4.0.3",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -8441,6 +8442,12 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.2.1",
     "react-device-detect": "^2.2.3",
     "react-dom": "^19.2.1",
+    "simplex-noise": "^4.0.3",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/app/api/ron-runner/route.ts
+++ b/src/app/api/ron-runner/route.ts
@@ -135,13 +135,14 @@ async function processAITurn(playerId: string): Promise<{ success: boolean; acti
     // The ron-ai API returns newState (not updatedState)
     if (result.newState) {
       gameState = result.newState;
+      const newState = result.newState; // Local variable for TypeScript narrowing
       aiResponseIds.set(playerId, result.responseId || null);
       aiTurnCount++;
 
       const actions = result.actions || [];
       for (const action of actions) {
         recentActions.push({
-          tick: gameState.tick,
+          tick: newState.tick,
           playerId,
           type: action.type,
           args: action.data || {},

--- a/src/games/ron/components/RoNCanvas.tsx
+++ b/src/games/ron/components/RoNCanvas.tsx
@@ -40,6 +40,19 @@ import {
   drawFireEffect,
 } from '@/components/game/shared';
 import { drawRoNUnit } from '../lib/drawUnits';
+
+// Import enhanced graphics for realistic terrain rendering
+import {
+  drawEnhancedGrassTile,
+  drawEnhancedWaterTile,
+  drawEnhancedBeach,
+  drawEnhancedForest,
+  drawEnhancedMountain,
+  drawEnhancedOilDeposit,
+  drawEnhancedSky,
+  drawUnitShadow,
+  drawFishingSpot,
+} from '../lib/enhancedGraphics';
 import { getTerritoryOwner, extractCityCenters } from '../lib/simulation';
 
 /**
@@ -1261,8 +1274,8 @@ export function RoNCanvas({ navigationTarget, onNavigationComplete, onViewportCh
       // Disable image smoothing for crisp pixel art
       ctx.imageSmoothingEnabled = false;
       
-      // Draw sky background
-      drawSkyBackground(ctx, canvas, 'day');
+      // Draw enhanced sky background with atmospheric effects
+      drawEnhancedSky(ctx, canvas, fireAnimTimeRef.current, { timeOfDay: 'day', clouds: true });
       
       // Get sprite sheet for current player's age
       const playerAge = currentPlayer?.age || 'classical';
@@ -1308,379 +1321,49 @@ export function RoNCanvas({ navigationTarget, onNavigationComplete, onViewportCh
               south: x < gameState.gridSize - 1 && gameState.grid[y]?.[x + 1]?.terrain === 'water',
               west: y < gameState.gridSize - 1 && gameState.grid[y + 1]?.[x]?.terrain === 'water',
             };
-            drawWaterTile(ctx, screenX, screenY, x, y, adjacentWater);
+            // Use enhanced water with animated waves and depth-based color
+            drawEnhancedWaterTile(ctx, screenX, screenY, x, y, fireAnimTimeRef.current, currentZoom, adjacentWater, { sparkle: true });
             
-            // Draw fishing spot indicator
+            // Draw fishing spot indicator with enhanced animation
             if (tile.hasFishingSpot) {
-              const cx = screenX + TILE_WIDTH / 2;
-              const cy = screenY + TILE_HEIGHT / 2;
-              
-              // Draw ripples/fish silhouette
-              ctx.save();
-              ctx.globalAlpha = 0.5;
-              
-              // Draw concentric ripples
-              ctx.strokeStyle = '#ffffff';
-              ctx.lineWidth = 0.8;
-              
-              // Animated ripple effect based on tile position
-              const time = performance.now() / 1000;
-              const phase = ((x + y) * 0.3 + time) % (Math.PI * 2);
-              const rippleSize = 3 + Math.sin(phase) * 2;
-              
-              ctx.beginPath();
-              ctx.ellipse(cx, cy, rippleSize * 2, rippleSize, 0, 0, Math.PI * 2);
-              ctx.stroke();
-              
-              ctx.beginPath();
-              ctx.ellipse(cx, cy, rippleSize * 3.5, rippleSize * 1.75, 0, 0, Math.PI * 2);
-              ctx.stroke();
-              
-              // Draw small fish silhouette
-              ctx.fillStyle = '#4a90a4';
-              ctx.globalAlpha = 0.4;
-              const fishX = cx + Math.sin(phase * 2) * 4;
-              const fishY = cy + Math.cos(phase) * 2;
-              
-              // Fish body (ellipse)
-              ctx.beginPath();
-              ctx.ellipse(fishX, fishY, 4, 2, Math.sin(phase) * 0.3, 0, Math.PI * 2);
-              ctx.fill();
-              
-              // Fish tail
-              ctx.beginPath();
-              ctx.moveTo(fishX - 4, fishY);
-              ctx.lineTo(fishX - 7, fishY - 2);
-              ctx.lineTo(fishX - 7, fishY + 2);
-              ctx.closePath();
-              ctx.fill();
-              
-              ctx.restore();
+              drawFishingSpot(ctx, screenX, screenY, fireAnimTimeRef.current, currentZoom);
             }
           } else if (isPartOfDock) {
-            // Draw water tile for dock footprint (like IsoCity marina)
-            // Check adjacent water for proper blending
+            // Draw enhanced water tile for dock footprint
             const adjacentWater = {
               north: x > 0 && (gameState.grid[y]?.[x - 1]?.terrain === 'water' || hasDock(gameState.grid, x - 1, y, gameState.gridSize)),
               east: y > 0 && (gameState.grid[y - 1]?.[x]?.terrain === 'water' || hasDock(gameState.grid, x, y - 1, gameState.gridSize)),
               south: x < gameState.gridSize - 1 && (gameState.grid[y]?.[x + 1]?.terrain === 'water' || hasDock(gameState.grid, x + 1, y, gameState.gridSize)),
               west: y < gameState.gridSize - 1 && (gameState.grid[y + 1]?.[x]?.terrain === 'water' || hasDock(gameState.grid, x, y + 1, gameState.gridSize)),
             };
-            drawWaterTile(ctx, screenX, screenY, x, y, adjacentWater);
+            drawEnhancedWaterTile(ctx, screenX, screenY, x, y, fireAnimTimeRef.current, currentZoom, adjacentWater, { sparkle: false });
           } else {
             // Determine zone color based on ownership/deposits
             let zoneType: 'none' | 'residential' | 'commercial' | 'industrial' = 'none';
             
             // Apply slight tinting for special tiles
             if (tile.hasMetalDeposit) {
-              // Draw mountainous terrain for metal deposits
-              // Base rocky ground with gradient
-              const gradient = ctx.createLinearGradient(
-                screenX, screenY,
-                screenX + TILE_WIDTH, screenY + TILE_HEIGHT
-              );
-              gradient.addColorStop(0, '#6b7280');
-              gradient.addColorStop(0.5, '#78716c');
-              gradient.addColorStop(1, '#57534e');
-              ctx.fillStyle = gradient;
-              ctx.beginPath();
-              ctx.moveTo(screenX + TILE_WIDTH / 2, screenY);
-              ctx.lineTo(screenX + TILE_WIDTH, screenY + TILE_HEIGHT / 2);
-              ctx.lineTo(screenX + TILE_WIDTH / 2, screenY + TILE_HEIGHT);
-              ctx.lineTo(screenX, screenY + TILE_HEIGHT / 2);
-              ctx.closePath();
-              ctx.fill();
-              
-              // Deterministic seed for this tile
-              const seed = x * 1000 + y;
-              
-              // Draw clustered mountain peaks (6-8 per tile, tightly packed, taller)
-              const numMountains = 6 + (seed % 3);
-              
-              // Tighter cluster positions near center with varying heights
-              const mountainPositions = [
-                { dx: 0.5, dy: 0.28, sizeMult: 1.4, heightMult: 1.3 },   // Back center - tallest
-                { dx: 0.35, dy: 0.32, sizeMult: 1.2, heightMult: 1.1 }, // Back left
-                { dx: 0.65, dy: 0.32, sizeMult: 1.2, heightMult: 1.15 },  // Back right
-                { dx: 0.42, dy: 0.42, sizeMult: 1.0, heightMult: 0.9 }, // Mid left
-                { dx: 0.58, dy: 0.44, sizeMult: 1.1, heightMult: 0.95 },  // Mid right
-                { dx: 0.5, dy: 0.52, sizeMult: 0.9, heightMult: 0.8 },   // Front center
-                { dx: 0.32, dy: 0.50, sizeMult: 0.7, heightMult: 0.65 },  // Front left edge
-                { dx: 0.68, dy: 0.48, sizeMult: 0.75, heightMult: 0.7 },  // Front right edge
-              ];
-              
-              // Draw mountains with more detail
-              for (let m = 0; m < Math.min(numMountains, mountainPositions.length); m++) {
-                const pos = mountainPositions[m];
-                const mSeed = seed * 7 + m * 13;
-                
-                // Tight clustering with minimal randomization
-                const baseX = screenX + TILE_WIDTH * pos.dx + ((mSeed % 5) - 2.5) * 0.4;
-                const baseY = screenY + TILE_HEIGHT * pos.dy + ((mSeed * 3 % 4) - 2) * 0.2;
-                
-                // Taller mountains with some width variation
-                const baseWidth = (14 + (mSeed % 5)) * pos.sizeMult;
-                const peakHeight = (16 + (mSeed * 2 % 8)) * pos.heightMult;
-                const peakX = baseX + ((mSeed % 3) - 1) * 0.5; // Slight peak offset
-                const peakY = baseY - peakHeight;
-                
-                // Left face (shadow) with rocky texture
-                ctx.fillStyle = '#4a4a52';
-                ctx.beginPath();
-                ctx.moveTo(peakX, peakY);
-                // Add a slight ridge on the left face
-                const leftRidgeX = baseX - baseWidth * 0.3;
-                const leftRidgeY = baseY - peakHeight * 0.4;
-                ctx.lineTo(leftRidgeX, leftRidgeY);
-                ctx.lineTo(baseX - baseWidth * 0.5, baseY);
-                ctx.lineTo(baseX, baseY);
-                ctx.closePath();
-                ctx.fill();
-                
-                // Right face (lit) with subtle detail
-                ctx.fillStyle = '#9ca3af';
-                ctx.beginPath();
-                ctx.moveTo(peakX, peakY);
-                // Add a slight ridge on the right face
-                const rightRidgeX = baseX + baseWidth * 0.25;
-                const rightRidgeY = baseY - peakHeight * 0.35;
-                ctx.lineTo(rightRidgeX, rightRidgeY);
-                ctx.lineTo(baseX + baseWidth * 0.5, baseY);
-                ctx.lineTo(baseX, baseY);
-                ctx.closePath();
-                ctx.fill();
-                
-                // Add a darker ridge line on larger mountains
-                if (pos.heightMult > 0.8) {
-                  ctx.fillStyle = '#3f3f46';
-                  ctx.beginPath();
-                  ctx.moveTo(peakX, peakY);
-                  ctx.lineTo(peakX - 1, peakY + peakHeight * 0.5);
-                  ctx.lineTo(peakX + 1, peakY + peakHeight * 0.5);
-                  ctx.closePath();
-                  ctx.fill();
-                }
-                
-                // Snow cap on taller peaks
-                if (pos.heightMult >= 1.0) {
-                  const snowHeight = peakHeight * 0.25;
-                  ctx.fillStyle = '#f5f5f5';
-                  ctx.beginPath();
-                  ctx.moveTo(peakX, peakY);
-                  ctx.lineTo(peakX - baseWidth * 0.1, peakY + snowHeight);
-                  ctx.lineTo(peakX + baseWidth * 0.1, peakY + snowHeight);
-                  ctx.closePath();
-                  ctx.fill();
-                  
-                  // Snow drip effect
-                  if (pos.heightMult >= 1.2) {
-                    ctx.fillStyle = '#e5e5e5';
-                    ctx.beginPath();
-                    ctx.arc(peakX - 2, peakY + snowHeight + 2, 1.5, 0, Math.PI * 2);
-                    ctx.fill();
-                  }
-                }
-              }
-              
-              // Smaller ore deposits (dark diamonds) at base - 4-6 deposits
-              const numOreDeposits = 4 + (seed % 3);
-              const orePositions = [
-                { dx: 0.28, dy: 0.70 },
-                { dx: 0.42, dy: 0.74 },
-                { dx: 0.58, dy: 0.72 },
-                { dx: 0.72, dy: 0.70 },
-                { dx: 0.38, dy: 0.66 },
-                { dx: 0.62, dy: 0.68 },
-              ];
-              
-              for (let o = 0; o < Math.min(numOreDeposits, orePositions.length); o++) {
-                const oPos = orePositions[o];
-                const oSeed = seed * 11 + o * 17;
-                const oreX = screenX + TILE_WIDTH * oPos.dx + ((oSeed % 4) - 2) * 0.3;
-                const oreY = screenY + TILE_HEIGHT * oPos.dy + ((oSeed * 2 % 3) - 1) * 0.2;
-                const oreSize = 1.5 + (oSeed % 2); // Smaller ore pieces
-                
-                // Dark ore diamond shape (more interesting than square)
-                ctx.fillStyle = '#18181b';
-                ctx.beginPath();
-                ctx.moveTo(oreX, oreY - oreSize);
-                ctx.lineTo(oreX + oreSize, oreY);
-                ctx.lineTo(oreX, oreY + oreSize);
-                ctx.lineTo(oreX - oreSize, oreY);
-                ctx.closePath();
-                ctx.fill();
-                
-                // Tiny metallic glint
-                ctx.fillStyle = '#71717a';
-                ctx.fillRect(oreX - 0.5, oreY - 0.5, 1, 1);
-              }
-              
-              // More grey boulders/circles at bottom - 7-10 boulders
-              const numBoulders = 7 + (seed % 4);
-              for (let b = 0; b < numBoulders; b++) {
-                const bSeed = seed * 19 + b * 23;
-                const bx = screenX + TILE_WIDTH * 0.2 + ((bSeed % 100) / 100) * TILE_WIDTH * 0.6;
-                const by = screenY + TILE_HEIGHT * 0.58 + ((bSeed * 3 % 50) / 100) * TILE_HEIGHT * 0.35;
-                const bSize = 2 + (bSeed % 3);
-                
-                // Grey boulder
-                ctx.fillStyle = '#6b7280';
-                ctx.beginPath();
-                ctx.arc(bx, by, bSize, 0, Math.PI * 2);
-                ctx.fill();
-                
-                // Light highlight
-                ctx.fillStyle = '#a1a1aa';
-                ctx.beginPath();
-                ctx.arc(bx - bSize * 0.25, by - bSize * 0.25, bSize * 0.35, 0, Math.PI * 2);
-                ctx.fill();
-              }
+              // Draw enhanced mountain/metal deposit with realistic shading and ore glints
+              drawEnhancedMountain(ctx, screenX, screenY, x, y, true, fireAnimTimeRef.current, currentZoom, { height: 1.0 });
             } else if (tile.hasOilDeposit) {
-              // Draw grass base first
-              drawGroundTile(ctx, screenX, screenY, 'none', currentZoom, false);
+              // Draw grass base first using enhanced terrain
+              drawEnhancedGrassTile(ctx, screenX, screenY, x, y, currentZoom, {});
               
               // Only show oil in industrial+ ages
               const isIndustrial = AGE_ORDER.indexOf(playerAge) >= AGE_ORDER.indexOf('industrial');
               if (isIndustrial) {
-                // Deterministic seed for this tile
-                const seed = x * 31 + y * 17;
-                
-                // Generate 4-6 overlapping oil splotches of similar sizes
-                const numSplotches = 4 + (seed % 3); // 4, 5, or 6 splotches
-                
-                // Splotch configurations (deterministic based on seed)
-                const splotches: Array<{ dx: number; dy: number; w: number; h: number; angle: number }> = [];
-                for (let i = 0; i < numSplotches; i++) {
-                  const splotchSeed = seed * 7 + i * 13;
-                  // Random size for each - all similar range (0.08 to 0.14)
-                  const baseSize = 0.08 + (splotchSeed % 60) / 1000; // 0.08 to 0.14
-                  splotches.push({
-                    // Position offset from center (spread more across tile)
-                    dx: ((splotchSeed % 70) - 35) / 100 * TILE_WIDTH * 0.55,
-                    dy: ((splotchSeed * 3 % 50) - 25) / 100 * TILE_HEIGHT * 0.55,
-                    // All splotches similar size with random variation
-                    w: TILE_WIDTH * baseSize,
-                    h: TILE_HEIGHT * (baseSize * 0.8 + (splotchSeed * 2 % 30) / 1000),
-                    // More rotation for variety
-                    angle: ((splotchSeed * 5) % 90 - 45) * Math.PI / 180,
-                  });
-                }
-                
-                const cx = screenX + TILE_WIDTH / 2;
-                const cy = screenY + TILE_HEIGHT / 2;
-                
-                // Draw splotches in random order (no size sorting - they're all similar)
-                for (let i = 0; i < splotches.length; i++) {
-                  const s = splotches[i];
-                  const px = cx + s.dx;
-                  const py = cy + s.dy;
-                  
-                  // Dark oil base - slight variation in darkness
-                  const darkness = 8 + (i * 2 % 6);
-                  ctx.fillStyle = `rgb(${darkness}, ${darkness}, ${darkness + 4})`;
-                  ctx.beginPath();
-                  ctx.ellipse(px, py, s.w, s.h, s.angle, 0, Math.PI * 2);
-                  ctx.fill();
-                  
-                  // Subtle glossy highlight on each splotch
-                  ctx.fillStyle = 'rgba(50, 50, 70, 0.25)';
-                  ctx.beginPath();
-                  ctx.ellipse(
-                    px - s.w * 0.2, 
-                    py - s.h * 0.2, 
-                    s.w * 0.5, 
-                    s.h * 0.4, 
-                    s.angle, 
-                    0, 
-                    Math.PI * 2
-                  );
-                  ctx.fill();
-                }
-                
-                // Add tiny white highlights on a couple of splotches
-                ctx.fillStyle = 'rgba(255, 255, 255, 0.1)';
-                for (let i = 0; i < Math.min(2, splotches.length); i++) {
-                  const s = splotches[i];
-                  ctx.beginPath();
-                  ctx.ellipse(
-                    cx + s.dx - s.w * 0.25,
-                    cy + s.dy - s.h * 0.25,
-                    s.w * 0.25,
-                    s.h * 0.2,
-                    s.angle,
-                    0,
-                    Math.PI * 2
-                  );
-                  ctx.fill();
-                }
+                // Draw enhanced oil deposit with iridescent effect
+                drawEnhancedOilDeposit(ctx, screenX, screenY, x, y, fireAnimTimeRef.current, currentZoom, {});
               }
             } else if (tile.forestDensity > 0) {
-              // Draw base grass tile for forest
-              drawGroundTile(ctx, screenX, screenY, 'none', currentZoom, false);
-              
-              // Draw trees on forest tiles using IsoCity's tree sprite
-              const isoCitySprite = getCachedImage(ISOCITY_SPRITE_PATH, true);
-              if (isoCitySprite) {
-                // Tree sprite is at row 3, col 0 in IsoCity's 5x6 grid
-                const treeCols = 5;
-                const treeRows = 6;
-                const treeTileWidth = isoCitySprite.width / treeCols;
-                const treeTileHeight = isoCitySprite.height / treeRows;
-                
-                // Crop top 15% to avoid bleeding from asset above, and bottom 5%
-                const cropTop = treeTileHeight * 0.15;
-                const cropBottom = treeTileHeight * 0.05;
-                const treeSx = 0 * treeTileWidth;  // col 0
-                const treeSy = 3 * treeTileHeight + cropTop; // row 3, offset down to avoid asset above
-                const treeSrcHeight = treeTileHeight - cropTop - cropBottom;
-
-                // Number of trees based on forest density (6-8 trees for dense forests)
-                const numTrees = 6 + Math.floor((tile.forestDensity / 100) * 2);
-
-                // Tree positions within the tile - spread across the diamond
-                const treePositions = [
-                  { dx: 0.5, dy: 0.35 },   // top-center
-                  { dx: 0.3, dy: 0.45 },   // upper-left
-                  { dx: 0.7, dy: 0.45 },   // upper-right
-                  { dx: 0.2, dy: 0.55 },   // mid-left
-                  { dx: 0.5, dy: 0.55 },   // center
-                  { dx: 0.8, dy: 0.55 },   // mid-right
-                  { dx: 0.35, dy: 0.65 },  // lower-left
-                  { dx: 0.65, dy: 0.65 },  // lower-right
-                ];
-
-                const treeAspect = treeSrcHeight / treeTileWidth;
-
-                for (let t = 0; t < numTrees; t++) {
-                  const pos = treePositions[t];
-                  // Use tile position to create variation in size and position
-                  const seed = (x * 31 + y * 17 + t * 7) % 100;
-                  const offsetX = (seed % 10 - 5) * 0.03 * TILE_WIDTH;
-                  const offsetY = (Math.floor(seed / 10) - 5) * 0.02 * TILE_HEIGHT;
-
-                  // Vary tree size (0.35 to 0.55 scale)
-                  const sizeSeed = (x * 13 + y * 23 + t * 11) % 100;
-                  const treeScale = 0.35 + (sizeSeed / 100) * 0.2;
-                  const treeDestWidth = TILE_WIDTH * treeScale;
-                  const treeDestHeight = treeDestWidth * treeAspect;
-
-                  const treeDrawX = screenX + TILE_WIDTH * pos.dx - treeDestWidth / 2 + offsetX;
-                  // Position trees higher (reduced the 0.3 to 0.15 offset)
-                  const treeDrawY = screenY + TILE_HEIGHT * pos.dy - treeDestHeight + TILE_HEIGHT * 0.15 + offsetY;
-
-                  ctx.drawImage(
-                    isoCitySprite,
-                    treeSx, treeSy, treeTileWidth, treeSrcHeight,
-                    treeDrawX, treeDrawY, treeDestWidth, treeDestHeight
-                  );
-                }
-              }
+              // Draw enhanced procedural forest with wind animation
+              drawEnhancedForest(ctx, screenX, screenY, x, y, tile.forestDensity / 100, fireAnimTimeRef.current, currentZoom, {});
             } else if (tile.building?.type === 'road') {
-              // Draw grass base under roads (roads are drawn on top in second pass)
-              drawGroundTile(ctx, screenX, screenY, 'none', currentZoom, false);
+              // Draw enhanced grass base under roads (roads are drawn on top in second pass)
+              drawEnhancedGrassTile(ctx, screenX, screenY, x, y, currentZoom, {});
             } else {
-              // Regular grass tile
-              drawGroundTile(ctx, screenX, screenY, zoneType, currentZoom, false);
+              // Regular enhanced grass tile with natural variation
+              drawEnhancedGrassTile(ctx, screenX, screenY, x, y, currentZoom, {});
             }
             
             // Ownership tint overlay (skip for roads)
@@ -1747,8 +1430,8 @@ export function RoNCanvas({ navigationTarget, onNavigationComplete, onViewportCh
         }
       }
       
-      // Beach pass: Draw beaches on water tiles adjacent to land (like IsoCity)
-      // Exclude beaches next to docks (like IsoCity does for marina/pier)
+      // Beach pass: Draw enhanced beaches on water tiles adjacent to land
+      // Features animated foam lines and realistic sand-to-water gradients
       for (let y = 0; y < gameState.gridSize; y++) {
         for (let x = 0; x < gameState.gridSize; x++) {
           const tile = gameState.grid[y]?.[x];
@@ -1773,9 +1456,9 @@ export function RoNCanvas({ navigationTarget, onNavigationComplete, onViewportCh
                   !hasDock(gameState.grid, x, y + 1, gameState.gridSize),
           };
 
-          // Draw beach if any adjacent tile is land (and not a dock)
+          // Draw enhanced beach with animated foam if any adjacent tile is land
           if (adjacentLand.north || adjacentLand.east || adjacentLand.south || adjacentLand.west) {
-            drawBeachOnWater(ctx, screenX, screenY, adjacentLand);
+            drawEnhancedBeach(ctx, screenX, screenY, x, y, fireAnimTimeRef.current, currentZoom, adjacentLand, {});
           }
         }
       }
@@ -2377,6 +2060,19 @@ export function RoNCanvas({ navigationTarget, onNavigationComplete, onViewportCh
       }
       
       // Fourth pass: Draw units with pedestrian-like sprites
+      // First draw all unit shadows for depth perception
+      gameState.units.forEach(unit => {
+        const { screenX, screenY } = gridToScreen(unit.x, unit.y, 0, 0);
+        if (!isTileVisible(screenX, screenY, viewBounds)) return;
+        
+        // Draw shadow at unit position
+        const unitCenterX = screenX + TILE_WIDTH / 2;
+        const unitCenterY = screenY + TILE_HEIGHT * 0.35;
+        const shadowSize = 6;
+        drawUnitShadow(ctx, unitCenterX, unitCenterY, shadowSize, { offsetX: 2, offsetY: 3, blur: 0.25 });
+      });
+      
+      // Then draw all units on top of shadows
       gameState.units.forEach(unit => {
         const { screenX, screenY } = gridToScreen(unit.x, unit.y, 0, 0);
         

--- a/src/games/ron/lib/drawUnits.ts
+++ b/src/games/ron/lib/drawUnits.ts
@@ -3,28 +3,59 @@
  * 
  * Renders units with pedestrian-like sprites and task-based activities.
  * Inspired by IsoCity's pedestrian system but simplified for RTS units.
+ * 
+ * ENHANCED: Uses muted, era-appropriate color palettes for realistic appearance.
  */
 
 import { Unit, UnitTask, UNIT_STATS } from '../types/units';
 import { TILE_WIDTH, TILE_HEIGHT, gridToScreen } from '@/components/game/shared';
 
-// Skin tone colors (similar to IsoCity)
-const SKIN_TONES = ['#f5d0c5', '#e8beac', '#d4a574', '#c68642', '#8d5524', '#5c3317'];
+// Realistic skin tone colors - muted, natural tones
+const SKIN_TONES = [
+  '#e8d4c4', // Fair
+  '#d4b8a0', // Light
+  '#c49a6c', // Medium
+  '#a67c52', // Tan
+  '#7a5838', // Brown
+  '#4a3628', // Dark
+];
 
-// Clothing colors for civilians
-const CIVILIAN_COLORS = ['#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+// Hair colors - natural tones
+const HAIR_COLORS = [
+  '#1a1512', // Black
+  '#3a2a1e', // Dark brown
+  '#5c4033', // Brown
+  '#8b6040', // Light brown
+  '#c4a070', // Blonde
+  '#6a4535', // Auburn
+];
 
-// Hair colors
-const HAIR_COLORS = ['#2c1810', '#4a3728', '#8b4513', '#d4a574', '#f5deb3', '#1a1a1a'];
-
-// Tool colors for different tasks
+// Tool colors for different tasks - realistic wood/metal tones
 const TOOL_COLORS: Record<string, string> = {
-  gather_wood: '#8b4513',   // Brown axe
-  gather_metal: '#6b7280',  // Grey pickaxe
-  gather_food: '#f59e0b',   // Golden scythe
-  gather_gold: '#fbbf24',   // Gold pan
-  gather_oil: '#1f2937',    // Dark oil tool
-  build: '#a16207',         // Hammer
+  gather_wood: '#5c4033',   // Dark wood axe handle
+  gather_metal: '#52525b',  // Steel grey pickaxe
+  gather_food: '#a8a29e',   // Iron scythe
+  gather_gold: '#b8860b',   // Dark gold pan
+  gather_oil: '#27272a',    // Dark metal tool
+  build: '#78716c',         // Steel hammer
+};
+
+// Muted metal colors for weapons and armor
+const METAL_COLORS = {
+  iron: '#6b7280',
+  steel: '#78716c',
+  bronze: '#a67c52',
+  gold: '#b8860b',
+  dark: '#3f3f46',
+};
+
+// Wood and leather colors
+const MATERIAL_COLORS = {
+  woodLight: '#8b7355',
+  woodDark: '#5c4033',
+  leather: '#6b5344',
+  leatherDark: '#4a3728',
+  cloth: '#a8a29e',
 };
 
 /**
@@ -44,7 +75,6 @@ function getUnitIdHash(unitId: string): number {
  */
 function getUnitAppearance(unitId: string): {
   skinTone: string;
-  clothingColor: string;
   hairColor: string;
   hasTool: boolean;
 } {
@@ -53,7 +83,6 @@ function getUnitAppearance(unitId: string): {
   
   return {
     skinTone: SKIN_TONES[absHash % SKIN_TONES.length],
-    clothingColor: CIVILIAN_COLORS[(absHash >> 4) % CIVILIAN_COLORS.length],
     hairColor: HAIR_COLORS[(absHash >> 8) % HAIR_COLORS.length],
     hasTool: true,
   };
@@ -1837,8 +1866,8 @@ function drawDestroyer(ctx: CanvasRenderingContext2D, cx: number, cy: number, co
   ctx.closePath();
   ctx.fill();
   
-  // Main hull - sleek destroyer shape with player color accent
-  ctx.fillStyle = '#5a6270';
+  // Main hull - sleek destroyer shape with realistic navy grey
+  ctx.fillStyle = '#4b5563'; // Naval grey
   ctx.beginPath();
   ctx.moveTo(cx - w * 0.4, cy + bob + h * 0.15);
   ctx.lineTo(cx + w * 0.5, cy + bob - h * 0.1);

--- a/src/games/ron/lib/enhancedGraphics.ts
+++ b/src/games/ron/lib/enhancedGraphics.ts
@@ -1,0 +1,1417 @@
+/**
+ * Rise of Nations - Enhanced Graphics System
+ * 
+ * High-fidelity terrain, water, lighting, and effects rendering.
+ * Focus on realistic, grounded visuals - muted earth tones, proper depth,
+ * and believable natural elements rather than cartoon-y gradients.
+ */
+
+import { createNoise2D, NoiseFunction2D } from 'simplex-noise';
+import { TILE_WIDTH, TILE_HEIGHT } from '@/components/game/shared';
+
+// ============================================================================
+// NOISE GENERATORS (lazy initialization for performance)
+// ============================================================================
+
+let terrainNoise: NoiseFunction2D | null = null;
+let grassDetailNoise: NoiseFunction2D | null = null;
+let waterNoise: NoiseFunction2D | null = null;
+let waveNoise: NoiseFunction2D | null = null;
+let cloudNoise: NoiseFunction2D | null = null;
+let forestNoise: NoiseFunction2D | null = null;
+
+function getTerrainNoise(): NoiseFunction2D {
+  if (!terrainNoise) terrainNoise = createNoise2D();
+  return terrainNoise;
+}
+
+function getGrassDetailNoise(): NoiseFunction2D {
+  if (!grassDetailNoise) grassDetailNoise = createNoise2D();
+  return grassDetailNoise;
+}
+
+function getWaterNoise(): NoiseFunction2D {
+  if (!waterNoise) waterNoise = createNoise2D();
+  return waterNoise;
+}
+
+function getWaveNoise(): NoiseFunction2D {
+  if (!waveNoise) waveNoise = createNoise2D();
+  return waveNoise;
+}
+
+function getCloudNoise(): NoiseFunction2D {
+  if (!cloudNoise) cloudNoise = createNoise2D();
+  return cloudNoise;
+}
+
+function getForestNoise(): NoiseFunction2D {
+  if (!forestNoise) forestNoise = createNoise2D();
+  return forestNoise;
+}
+
+// ============================================================================
+// REALISTIC COLOR PALETTES - Earth tones, not cartoon-y
+// ============================================================================
+
+/** Realistic grass/terrain colors - muted, natural earth tones */
+export const TERRAIN_COLORS = {
+  // Grass variants - muted greens with earth undertones
+  grassDark: { r: 76, g: 100, b: 58 },      // Dark earthy green
+  grassMid: { r: 98, g: 120, b: 72 },       // Mid grass
+  grassLight: { r: 122, g: 142, b: 88 },    // Light grass
+  grassDry: { r: 140, g: 135, b: 85 },      // Dry/parched grass
+  
+  // Dirt/earth variants
+  dirtDark: { r: 92, g: 72, b: 52 },        // Dark rich soil
+  dirtMid: { r: 120, g: 95, b: 68 },        // Mid brown earth
+  dirtLight: { r: 148, g: 120, b: 88 },     // Light sandy soil
+  dirtRed: { r: 138, g: 88, b: 62 },        // Red clay
+  
+  // Stone/rock
+  stoneDark: { r: 72, g: 75, b: 78 },
+  stoneMid: { r: 112, g: 115, b: 118 },
+  stoneLight: { r: 155, g: 158, b: 162 },
+  
+  // Grid stroke
+  stroke: 'rgba(40, 50, 35, 0.15)',
+};
+
+/** Realistic water colors - deeper blues, proper depth gradient */
+export const WATER_COLORS = {
+  deep: { r: 28, g: 58, b: 92 },           // Deep ocean
+  mid: { r: 42, g: 82, b: 120 },           // Mid water
+  shallow: { r: 72, g: 115, b: 145 },      // Shallow water
+  veryShallow: { r: 95, g: 140, b: 162 },  // Very shallow/coastal
+  foam: { r: 225, g: 235, b: 245 },        // Wave foam
+  sparkle: { r: 255, g: 255, b: 255 },     // Sun sparkle
+  reflection: { r: 140, g: 175, b: 200 },  // Sky reflection
+};
+
+/** Realistic beach/sand colors */
+export const BEACH_COLORS = {
+  dry: { r: 218, g: 195, b: 160 },         // Dry sand
+  damp: { r: 185, g: 165, b: 130 },        // Damp sand
+  wet: { r: 145, g: 128, b: 98 },          // Wet sand near water
+  dark: { r: 118, g: 105, b: 82 },         // Dark wet sand
+  pebbles: { r: 130, g: 125, b: 115 },     // Beach pebbles
+};
+
+/** Forest colors - natural woodland tones */
+export const FOREST_COLORS = {
+  canopyDark: { r: 32, g: 55, b: 35 },     // Dark canopy shadow
+  canopyMid: { r: 52, g: 78, b: 48 },      // Mid canopy
+  canopyLight: { r: 75, g: 102, b: 62 },   // Sunlit canopy
+  highlight: { r: 95, g: 125, b: 72 },     // Bright highlights
+  trunk: { r: 68, g: 52, b: 38 },          // Tree trunk
+  trunkDark: { r: 48, g: 38, b: 28 },      // Dark trunk/shadow
+  groundShadow: { r: 45, g: 58, b: 42 },   // Forest floor shadow
+};
+
+/** Mountain/rock colors */
+export const MOUNTAIN_COLORS = {
+  baseDark: { r: 65, g: 62, b: 58 },       // Dark rock base
+  baseMid: { r: 95, g: 90, b: 85 },        // Mid rock
+  baseLight: { r: 125, g: 118, b: 112 },   // Light rock
+  peak: { r: 148, g: 142, b: 138 },        // Peak color
+  shadow: { r: 48, g: 45, b: 42 },         // Deep shadow
+  snow: { r: 245, g: 248, b: 252 },        // Snow cap
+  snowShadow: { r: 195, g: 205, b: 215 },  // Snow in shadow
+  ore: { r: 165, g: 120, b: 65 },          // Ore/metal deposit
+  oreGlint: { r: 220, g: 180, b: 100 },    // Ore sparkle
+};
+
+/** Oil deposit colors */
+export const OIL_COLORS = {
+  slick: { r: 25, g: 22, b: 18 },          // Dark oil
+  sheen: { r: 45, g: 42, b: 38 },          // Oil sheen
+  rainbow: { r: 90, g: 80, b: 120 },       // Iridescent effect
+};
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/** Convert RGB object to CSS string */
+function rgb(color: { r: number; g: number; b: number }, alpha = 1): string {
+  return alpha === 1 
+    ? `rgb(${color.r}, ${color.g}, ${color.b})`
+    : `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})`;
+}
+
+/** Linear interpolation */
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t));
+}
+
+/** Interpolate between two colors */
+function lerpColor(
+  c1: { r: number; g: number; b: number },
+  c2: { r: number; g: number; b: number },
+  t: number
+): { r: number; g: number; b: number } {
+  return {
+    r: Math.round(lerp(c1.r, c2.r, t)),
+    g: Math.round(lerp(c1.g, c2.g, t)),
+    b: Math.round(lerp(c1.b, c2.b, t)),
+  };
+}
+
+/** Multi-octave noise for natural patterns */
+function octaveNoise(
+  noise: NoiseFunction2D,
+  x: number,
+  y: number,
+  octaves: number,
+  persistence: number,
+  scale: number
+): number {
+  let total = 0;
+  let frequency = scale;
+  let amplitude = 1;
+  let maxValue = 0;
+
+  for (let i = 0; i < octaves; i++) {
+    total += noise(x * frequency, y * frequency) * amplitude;
+    maxValue += amplitude;
+    amplitude *= persistence;
+    frequency *= 2;
+  }
+
+  return total / maxValue;
+}
+
+/** Simple deterministic hash for consistent per-tile randomness */
+function tileHash(x: number, y: number, seed = 0): number {
+  const n = Math.sin(x * 12.9898 + y * 78.233 + seed) * 43758.5453;
+  return n - Math.floor(n);
+}
+
+// ============================================================================
+// CACHED PATTERNS FOR PERFORMANCE
+// ============================================================================
+
+const patternCache = new Map<string, CanvasPattern | null>();
+
+/** Get or create a cached pattern */
+function getCachedPattern(
+  ctx: CanvasRenderingContext2D,
+  key: string,
+  width: number,
+  height: number,
+  drawFn: (pctx: CanvasRenderingContext2D) => void
+): CanvasPattern | null {
+  if (patternCache.has(key)) {
+    return patternCache.get(key)!;
+  }
+
+  const patternCanvas = document.createElement('canvas');
+  patternCanvas.width = width;
+  patternCanvas.height = height;
+  const pctx = patternCanvas.getContext('2d');
+  if (!pctx) return null;
+
+  drawFn(pctx);
+
+  const pattern = ctx.createPattern(patternCanvas, 'repeat');
+  patternCache.set(key, pattern);
+  return pattern;
+}
+
+// ============================================================================
+// ENHANCED TERRAIN RENDERING
+// ============================================================================
+
+/**
+ * Draw a realistic grass/terrain tile with natural variation
+ */
+export function drawEnhancedGrassTile(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  zoom: number,
+  options: {
+    ambient?: number;
+    highlight?: boolean;
+    selected?: boolean;
+    territoryOwner?: string | null;
+    territoryColor?: string;
+  } = {}
+): void {
+  const { ambient = 1.0, highlight = false, selected = false, territoryOwner, territoryColor } = options;
+  const noise = getTerrainNoise();
+  const detailNoise = getGrassDetailNoise();
+
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Get procedural variation for this tile
+  const terrainVal = octaveNoise(noise, gridX * 0.15, gridY * 0.15, 3, 0.5, 0.1);
+  const detailVal = octaveNoise(detailNoise, gridX * 0.4, gridY * 0.4, 2, 0.6, 0.2);
+  const patchVal = tileHash(gridX, gridY);
+  
+  // Determine grass/dirt mix based on noise
+  // Most tiles are grass, some have dirt patches
+  const dirtAmount = Math.max(0, terrainVal * 0.5 + patchVal * 0.2 - 0.3);
+  const isDryPatch = patchVal > 0.85;
+  
+  // Base grass color with variation
+  let baseColor: { r: number; g: number; b: number };
+  if (isDryPatch) {
+    baseColor = lerpColor(TERRAIN_COLORS.grassMid, TERRAIN_COLORS.grassDry, patchVal - 0.85);
+  } else {
+    const grassT = (terrainVal + 1) / 2;
+    baseColor = lerpColor(TERRAIN_COLORS.grassDark, TERRAIN_COLORS.grassLight, grassT);
+  }
+  
+  // Mix in dirt for variation
+  if (dirtAmount > 0.1) {
+    const dirtT = (detailVal + 1) / 2;
+    const dirtColor = lerpColor(TERRAIN_COLORS.dirtDark, TERRAIN_COLORS.dirtLight, dirtT);
+    baseColor = lerpColor(baseColor, dirtColor, Math.min(dirtAmount * 0.4, 0.3));
+  }
+  
+  // Apply ambient lighting
+  const litColor = {
+    r: Math.round(baseColor.r * ambient),
+    g: Math.round(baseColor.g * ambient),
+    b: Math.round(baseColor.b * ambient),
+  };
+
+  // Draw base tile
+  ctx.fillStyle = rgb(litColor);
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.fill();
+
+  // Add subtle texture variation when zoomed in
+  if (zoom >= 0.5) {
+    ctx.save();
+    // Clip to tile
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.clip();
+
+    // Draw subtle grass texture strokes
+    const numStrokes = zoom >= 0.8 ? 6 : 3;
+    for (let i = 0; i < numStrokes; i++) {
+      const hash = tileHash(gridX, gridY, i * 7);
+      const hash2 = tileHash(gridX + 1, gridY + 1, i * 11);
+      
+      const offsetX = (hash - 0.5) * w * 0.8;
+      const offsetY = (hash2 - 0.5) * h * 0.8;
+      const strokeX = cx + offsetX;
+      const strokeY = cy + offsetY;
+      
+      // Subtle variation in stroke color
+      const strokeBrightness = 0.85 + hash * 0.3;
+      const strokeColor = {
+        r: Math.min(255, Math.round(litColor.r * strokeBrightness)),
+        g: Math.min(255, Math.round(litColor.g * strokeBrightness)),
+        b: Math.min(255, Math.round(litColor.b * strokeBrightness)),
+      };
+      
+      ctx.strokeStyle = rgb(strokeColor, 0.4);
+      ctx.lineWidth = 0.6;
+      ctx.beginPath();
+      ctx.moveTo(strokeX, strokeY);
+      ctx.lineTo(strokeX + (hash - 0.5) * 2, strokeY - 1.5 - hash * 1.5);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  // Draw subtle grid line
+  if (zoom >= 0.6) {
+    ctx.strokeStyle = TERRAIN_COLORS.stroke;
+    ctx.lineWidth = 0.4;
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.stroke();
+  }
+
+  // Territory overlay
+  if (territoryOwner && territoryColor) {
+    ctx.fillStyle = territoryColor;
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  // Highlight/selection
+  if (highlight || selected) {
+    ctx.fillStyle = selected 
+      ? 'rgba(34, 197, 94, 0.25)' 
+      : 'rgba(255, 255, 255, 0.12)';
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.fill();
+    
+    ctx.strokeStyle = selected ? '#22c55e' : 'rgba(255, 255, 255, 0.6)';
+    ctx.lineWidth = selected ? 2 : 1;
+    ctx.stroke();
+  }
+}
+
+// ============================================================================
+// ENHANCED WATER RENDERING
+// ============================================================================
+
+/**
+ * Draw realistic water with depth-based color, animated waves, and reflections
+ */
+export function drawEnhancedWaterTile(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  animTime: number,
+  zoom: number,
+  adjacentWater: { north: boolean; east: boolean; south: boolean; west: boolean },
+  options: {
+    ambient?: number;
+    sparkle?: boolean;
+  } = {}
+): void {
+  const { ambient = 1.0, sparkle = true } = options;
+  const waterNoiseFn = getWaterNoise();
+  const waveNoiseFn = getWaveNoise();
+
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Calculate depth based on adjacent water tiles
+  const numAdjacentWater = [adjacentWater.north, adjacentWater.east, adjacentWater.south, adjacentWater.west]
+    .filter(Boolean).length;
+  const depth = numAdjacentWater / 4; // 0 = edge, 1 = surrounded
+
+  // Select water color based on depth
+  let waterColor: { r: number; g: number; b: number };
+  if (depth < 0.25) {
+    waterColor = lerpColor(WATER_COLORS.veryShallow, WATER_COLORS.shallow, depth * 4);
+  } else if (depth < 0.5) {
+    waterColor = lerpColor(WATER_COLORS.shallow, WATER_COLORS.mid, (depth - 0.25) * 4);
+  } else {
+    waterColor = lerpColor(WATER_COLORS.mid, WATER_COLORS.deep, (depth - 0.5) * 2);
+  }
+
+  // Apply ambient lighting
+  waterColor = {
+    r: Math.round(waterColor.r * ambient),
+    g: Math.round(waterColor.g * ambient),
+    b: Math.round(waterColor.b * ambient),
+  };
+
+  // Draw base water
+  ctx.fillStyle = rgb(waterColor);
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.fill();
+
+  // Add wave effects
+  const waveTime = animTime * 0.8;
+  const waveNoise = waveNoiseFn(gridX * 0.3 + waveTime * 0.5, gridY * 0.3);
+  const waveIntensity = 0.15 + waveNoise * 0.1;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.clip();
+
+  // Draw subtle wave lines
+  if (zoom >= 0.4) {
+    const numWaves = 3;
+    for (let i = 0; i < numWaves; i++) {
+      const waveOffset = (animTime * 0.5 + i * 0.3) % 1;
+      const waveY = screenY + h * (0.2 + i * 0.25 + waveOffset * 0.15);
+      const waveAmp = 2 + Math.sin(animTime * 2 + i) * 1;
+      
+      // Wave highlight
+      ctx.strokeStyle = rgb(WATER_COLORS.reflection, 0.15 + waveIntensity * 0.1);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(screenX + w * 0.15, waveY);
+      ctx.quadraticCurveTo(
+        cx, waveY + waveAmp * Math.sin(animTime * 3 + i),
+        screenX + w * 0.85, waveY
+      );
+      ctx.stroke();
+    }
+  }
+
+  // Add sun sparkles on shallow water
+  if (sparkle && depth < 0.6 && zoom >= 0.5) {
+    const sparklePhase = animTime * 2;
+    const numSparkles = Math.floor(2 + depth * 3);
+    
+    for (let i = 0; i < numSparkles; i++) {
+      const hash = tileHash(gridX, gridY, i * 13);
+      const hash2 = tileHash(gridX + 1, gridY, i * 17);
+      const sparkleActive = Math.sin(sparklePhase + hash * Math.PI * 2) > 0.7;
+      
+      if (sparkleActive) {
+        const sparkleX = cx + (hash - 0.5) * w * 0.6;
+        const sparkleY = cy + (hash2 - 0.5) * h * 0.6;
+        const sparkleSize = 1 + hash * 1.5;
+        const sparkleAlpha = 0.3 + Math.sin(sparklePhase * 3 + hash * 10) * 0.2;
+        
+        ctx.fillStyle = rgb(WATER_COLORS.sparkle, sparkleAlpha);
+        ctx.beginPath();
+        ctx.arc(sparkleX, sparkleY, sparkleSize, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  ctx.restore();
+
+  // Subtle border for depth perception
+  if (zoom >= 0.6 && depth < 0.75) {
+    ctx.strokeStyle = rgb(WATER_COLORS.deep, 0.15);
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
+
+// ============================================================================
+// ENHANCED BEACH RENDERING
+// ============================================================================
+
+/**
+ * Draw realistic beach transition on a water tile near land
+ */
+export function drawEnhancedBeach(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  animTime: number,
+  zoom: number,
+  adjacentLand: { north: boolean; east: boolean; south: boolean; west: boolean },
+  options: {
+    ambient?: number;
+  } = {}
+): void {
+  const { ambient = 1.0 } = options;
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  const landDirections = Object.entries(adjacentLand)
+    .filter(([, hasLand]) => hasLand)
+    .map(([dir]) => dir);
+
+  if (landDirections.length === 0) return;
+
+  ctx.save();
+  
+  // Clip to tile
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.clip();
+
+  // Draw beach/sand gradient from each land direction
+  for (const dir of landDirections) {
+    let gradientStart: { x: number; y: number };
+    let gradientEnd: { x: number; y: number };
+    
+    switch (dir) {
+      case 'north':
+        gradientStart = { x: screenX + w * 0.25, y: screenY + h * 0.25 };
+        gradientEnd = { x: cx, y: cy };
+        break;
+      case 'east':
+        gradientStart = { x: screenX + w * 0.75, y: screenY + h * 0.25 };
+        gradientEnd = { x: cx, y: cy };
+        break;
+      case 'south':
+        gradientStart = { x: screenX + w * 0.75, y: screenY + h * 0.75 };
+        gradientEnd = { x: cx, y: cy };
+        break;
+      case 'west':
+        gradientStart = { x: screenX + w * 0.25, y: screenY + h * 0.75 };
+        gradientEnd = { x: cx, y: cy };
+        break;
+      default:
+        continue;
+    }
+
+    // Create sand gradient
+    const sandGradient = ctx.createLinearGradient(
+      gradientStart.x, gradientStart.y,
+      gradientEnd.x, gradientEnd.y
+    );
+
+    const dryColor = {
+      r: Math.round(BEACH_COLORS.dry.r * ambient),
+      g: Math.round(BEACH_COLORS.dry.g * ambient),
+      b: Math.round(BEACH_COLORS.dry.b * ambient),
+    };
+    const wetColor = {
+      r: Math.round(BEACH_COLORS.wet.r * ambient),
+      g: Math.round(BEACH_COLORS.wet.g * ambient),
+      b: Math.round(BEACH_COLORS.wet.b * ambient),
+    };
+
+    sandGradient.addColorStop(0, rgb(dryColor, 0.85));
+    sandGradient.addColorStop(0.4, rgb(wetColor, 0.6));
+    sandGradient.addColorStop(0.7, rgb(wetColor, 0.25));
+    sandGradient.addColorStop(1, 'transparent');
+
+    ctx.fillStyle = sandGradient;
+    ctx.fillRect(screenX - 2, screenY - 2, w + 4, h + 4);
+  }
+
+  // Draw foam line animation
+  if (zoom >= 0.5) {
+    const foamPhase = animTime * 0.6;
+    
+    for (const dir of landDirections) {
+      const foamOffset = Math.sin(foamPhase + tileHash(gridX, gridY, dir.charCodeAt(0)) * Math.PI * 2) * 0.15;
+      
+      let foamStart: { x: number; y: number };
+      let foamEnd: { x: number; y: number };
+      let foamMid: { x: number; y: number };
+      
+      const edgeOffset = 0.35 + foamOffset;
+      
+      switch (dir) {
+        case 'north':
+          foamStart = { x: screenX + w * 0.1, y: screenY + h * edgeOffset };
+          foamEnd = { x: screenX + w * 0.4, y: screenY + h * (edgeOffset - 0.1) };
+          foamMid = { x: screenX + w * 0.25, y: screenY + h * (edgeOffset - 0.02) };
+          break;
+        case 'east':
+          foamStart = { x: screenX + w * (1 - edgeOffset), y: screenY + h * 0.1 };
+          foamEnd = { x: screenX + w * (1 - edgeOffset + 0.1), y: screenY + h * 0.4 };
+          foamMid = { x: screenX + w * (1 - edgeOffset + 0.02), y: screenY + h * 0.25 };
+          break;
+        case 'south':
+          foamStart = { x: screenX + w * 0.6, y: screenY + h * (1 - edgeOffset + 0.1) };
+          foamEnd = { x: screenX + w * 0.9, y: screenY + h * (1 - edgeOffset) };
+          foamMid = { x: screenX + w * 0.75, y: screenY + h * (1 - edgeOffset + 0.02) };
+          break;
+        case 'west':
+          foamStart = { x: screenX + w * (edgeOffset - 0.1), y: screenY + h * 0.6 };
+          foamEnd = { x: screenX + w * edgeOffset, y: screenY + h * 0.9 };
+          foamMid = { x: screenX + w * (edgeOffset - 0.02), y: screenY + h * 0.75 };
+          break;
+        default:
+          continue;
+      }
+
+      // Draw foam line
+      const foamAlpha = 0.4 + Math.sin(foamPhase * 2) * 0.15;
+      ctx.strokeStyle = rgb(BEACH_COLORS.dry, foamAlpha);
+      ctx.lineWidth = 1.5 + Math.sin(foamPhase * 1.5) * 0.5;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(foamStart.x, foamStart.y);
+      ctx.quadraticCurveTo(foamMid.x, foamMid.y, foamEnd.x, foamEnd.y);
+      ctx.stroke();
+    }
+  }
+
+  ctx.restore();
+}
+
+// ============================================================================
+// ENHANCED FOREST RENDERING
+// ============================================================================
+
+/**
+ * Draw realistic procedural forest on a tile
+ */
+export function drawEnhancedForest(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  density: number,
+  animTime: number,
+  zoom: number,
+  options: {
+    ambient?: number;
+  } = {}
+): void {
+  const { ambient = 1.0 } = options;
+  const forestNoiseFn = getForestNoise();
+  
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Draw forest floor shadow first
+  const shadowColor = {
+    r: Math.round(FOREST_COLORS.groundShadow.r * ambient),
+    g: Math.round(FOREST_COLORS.groundShadow.g * ambient),
+    b: Math.round(FOREST_COLORS.groundShadow.b * ambient),
+  };
+  
+  ctx.fillStyle = rgb(shadowColor);
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.fill();
+
+  // Number of trees based on density
+  const numTrees = Math.floor(2 + density * 4);
+  
+  // Wind sway animation
+  const windPhase = animTime * 0.5;
+  const windStrength = 0.02 + forestNoiseFn(animTime * 0.1, 0) * 0.01;
+
+  ctx.save();
+  
+  // Clip to tile area
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY - h * 0.5);
+  ctx.lineTo(screenX + w + w * 0.2, cy);
+  ctx.lineTo(cx, screenY + h * 1.2);
+  ctx.lineTo(screenX - w * 0.2, cy);
+  ctx.closePath();
+  ctx.clip();
+
+  // Draw trees from back to front
+  const trees: { x: number; y: number; size: number; hash: number }[] = [];
+  
+  for (let i = 0; i < numTrees; i++) {
+    const hash = tileHash(gridX, gridY, i * 7);
+    const hash2 = tileHash(gridX + i, gridY + 1, i * 11);
+    
+    const treeX = cx + (hash - 0.5) * w * 0.7;
+    const treeY = cy + (hash2 - 0.5) * h * 0.6 - 5;
+    const treeSize = (0.6 + hash * 0.5) * (zoom >= 0.6 ? 1 : 0.8);
+    
+    trees.push({ x: treeX, y: treeY, size: treeSize, hash });
+  }
+  
+  // Sort by Y position (back to front)
+  trees.sort((a, b) => a.y - b.y);
+
+  for (const tree of trees) {
+    const { x: treeX, y: treeY, size, hash } = tree;
+    
+    // Wind sway for this tree
+    const treeSway = Math.sin(windPhase + hash * Math.PI * 4) * windStrength * size * 20;
+    
+    // Tree trunk
+    const trunkColor = {
+      r: Math.round(FOREST_COLORS.trunk.r * ambient),
+      g: Math.round(FOREST_COLORS.trunk.g * ambient),
+      b: Math.round(FOREST_COLORS.trunk.b * ambient),
+    };
+    
+    ctx.fillStyle = rgb(trunkColor);
+    ctx.beginPath();
+    ctx.moveTo(treeX - 1.5 * size, treeY);
+    ctx.lineTo(treeX - 1 * size + treeSway * 0.3, treeY - 8 * size);
+    ctx.lineTo(treeX + 1 * size + treeSway * 0.3, treeY - 8 * size);
+    ctx.lineTo(treeX + 1.5 * size, treeY);
+    ctx.closePath();
+    ctx.fill();
+
+    // Tree canopy (layered triangles)
+    const canopyLayers = 3;
+    for (let layer = 0; layer < canopyLayers; layer++) {
+      const layerOffset = layer * 5 * size;
+      const layerWidth = (8 - layer * 1.5) * size;
+      const layerHeight = 6 * size;
+      
+      // Vary color by layer
+      const colorT = layer / canopyLayers;
+      const canopyColor = lerpColor(FOREST_COLORS.canopyDark, FOREST_COLORS.canopyLight, colorT);
+      const litCanopy = {
+        r: Math.round(canopyColor.r * ambient),
+        g: Math.round(canopyColor.g * ambient),
+        b: Math.round(canopyColor.b * ambient),
+      };
+      
+      const layerCenterY = treeY - 10 * size - layerOffset + treeSway * (1 + layer * 0.3);
+      const layerCenterX = treeX + treeSway * (1 + layer * 0.5);
+      
+      ctx.fillStyle = rgb(litCanopy);
+      ctx.beginPath();
+      ctx.moveTo(layerCenterX, layerCenterY - layerHeight);
+      ctx.lineTo(layerCenterX + layerWidth / 2, layerCenterY);
+      ctx.lineTo(layerCenterX - layerWidth / 2, layerCenterY);
+      ctx.closePath();
+      ctx.fill();
+      
+      // Highlight on right side
+      if (zoom >= 0.6) {
+        const highlightColor = {
+          r: Math.round(FOREST_COLORS.highlight.r * ambient),
+          g: Math.round(FOREST_COLORS.highlight.g * ambient),
+          b: Math.round(FOREST_COLORS.highlight.b * ambient),
+        };
+        
+        ctx.fillStyle = rgb(highlightColor, 0.3);
+        ctx.beginPath();
+        ctx.moveTo(layerCenterX, layerCenterY - layerHeight);
+        ctx.lineTo(layerCenterX + layerWidth / 2, layerCenterY);
+        ctx.lineTo(layerCenterX + layerWidth / 4, layerCenterY);
+        ctx.lineTo(layerCenterX, layerCenterY - layerHeight / 2);
+        ctx.closePath();
+        ctx.fill();
+      }
+    }
+  }
+
+  ctx.restore();
+}
+
+// ============================================================================
+// ENHANCED MOUNTAIN RENDERING
+// ============================================================================
+
+/**
+ * Draw realistic mountain/metal deposit with detailed shading
+ */
+export function drawEnhancedMountain(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  hasOre: boolean,
+  animTime: number,
+  zoom: number,
+  options: {
+    ambient?: number;
+    height?: number; // 0.5-1.5 range for varied peak heights
+  } = {}
+): void {
+  const { ambient = 1.0, height = 1.0 } = options;
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Mountain base hash for consistent randomness
+  const baseHash = tileHash(gridX, gridY);
+  const peakOffset = (baseHash - 0.5) * w * 0.15;
+
+  // Rock base (bottom portion)
+  const baseColor = {
+    r: Math.round(MOUNTAIN_COLORS.baseDark.r * ambient),
+    g: Math.round(MOUNTAIN_COLORS.baseDark.g * ambient),
+    b: Math.round(MOUNTAIN_COLORS.baseDark.b * ambient),
+  };
+  
+  ctx.fillStyle = rgb(baseColor);
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY + h * 0.2);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.fill();
+
+  // Main peak
+  const peakHeight = 22 * height;
+  const peakX = cx + peakOffset;
+  const peakY = screenY + h * 0.2 - peakHeight;
+
+  // Shadow side (left)
+  const shadowColor = {
+    r: Math.round(MOUNTAIN_COLORS.shadow.r * ambient),
+    g: Math.round(MOUNTAIN_COLORS.shadow.g * ambient),
+    b: Math.round(MOUNTAIN_COLORS.shadow.b * ambient),
+  };
+  
+  ctx.fillStyle = rgb(shadowColor);
+  ctx.beginPath();
+  ctx.moveTo(peakX, peakY);
+  ctx.lineTo(screenX + w * 0.15, cy - h * 0.1);
+  ctx.lineTo(cx, screenY + h * 0.2);
+  ctx.lineTo(peakX, peakY);
+  ctx.closePath();
+  ctx.fill();
+
+  // Lit side (right)
+  const litColor = {
+    r: Math.round(MOUNTAIN_COLORS.baseMid.r * ambient * 1.1),
+    g: Math.round(MOUNTAIN_COLORS.baseMid.g * ambient * 1.1),
+    b: Math.round(MOUNTAIN_COLORS.baseMid.b * ambient * 1.1),
+  };
+  
+  ctx.fillStyle = rgb(litColor);
+  ctx.beginPath();
+  ctx.moveTo(peakX, peakY);
+  ctx.lineTo(screenX + w * 0.85, cy - h * 0.1);
+  ctx.lineTo(cx, screenY + h * 0.2);
+  ctx.lineTo(peakX, peakY);
+  ctx.closePath();
+  ctx.fill();
+
+  // Snow cap on tall peaks
+  if (height > 0.8 && zoom >= 0.5) {
+    const snowLineY = peakY + peakHeight * 0.35;
+    const snowColor = {
+      r: Math.round(MOUNTAIN_COLORS.snow.r * ambient),
+      g: Math.round(MOUNTAIN_COLORS.snow.g * ambient),
+      b: Math.round(MOUNTAIN_COLORS.snow.b * ambient),
+    };
+    
+    ctx.fillStyle = rgb(snowColor);
+    ctx.beginPath();
+    ctx.moveTo(peakX, peakY);
+    ctx.lineTo(peakX - 6 * height, snowLineY);
+    ctx.lineTo(peakX + 6 * height, snowLineY);
+    ctx.closePath();
+    ctx.fill();
+    
+    // Snow shadow
+    const snowShadow = {
+      r: Math.round(MOUNTAIN_COLORS.snowShadow.r * ambient),
+      g: Math.round(MOUNTAIN_COLORS.snowShadow.g * ambient),
+      b: Math.round(MOUNTAIN_COLORS.snowShadow.b * ambient),
+    };
+    
+    ctx.fillStyle = rgb(snowShadow, 0.4);
+    ctx.beginPath();
+    ctx.moveTo(peakX, peakY + 3);
+    ctx.lineTo(peakX - 4 * height, snowLineY);
+    ctx.lineTo(peakX, snowLineY);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  // Ore deposits with glint
+  if (hasOre && zoom >= 0.4) {
+    const numOreSpots = 3 + Math.floor(baseHash * 3);
+    const glintPhase = animTime * 1.5;
+    
+    for (let i = 0; i < numOreSpots; i++) {
+      const oreHash = tileHash(gridX, gridY, i * 23);
+      const oreHash2 = tileHash(gridX + 1, gridY, i * 29);
+      
+      const oreX = cx + (oreHash - 0.5) * w * 0.5;
+      const oreY = cy + (oreHash2 - 0.5) * h * 0.4 - 5;
+      const oreSize = 2 + oreHash * 2;
+      
+      // Base ore color
+      const oreColor = {
+        r: Math.round(MOUNTAIN_COLORS.ore.r * ambient),
+        g: Math.round(MOUNTAIN_COLORS.ore.g * ambient),
+        b: Math.round(MOUNTAIN_COLORS.ore.b * ambient),
+      };
+      
+      ctx.fillStyle = rgb(oreColor);
+      ctx.beginPath();
+      ctx.arc(oreX, oreY, oreSize, 0, Math.PI * 2);
+      ctx.fill();
+      
+      // Glint animation
+      const glintActive = Math.sin(glintPhase + oreHash * Math.PI * 4) > 0.6;
+      if (glintActive) {
+        const glintColor = {
+          r: Math.round(MOUNTAIN_COLORS.oreGlint.r * ambient),
+          g: Math.round(MOUNTAIN_COLORS.oreGlint.g * ambient),
+          b: Math.round(MOUNTAIN_COLORS.oreGlint.b * ambient),
+        };
+        
+        const glintAlpha = 0.5 + Math.sin(glintPhase * 3 + oreHash * 10) * 0.3;
+        ctx.fillStyle = rgb(glintColor, glintAlpha);
+        ctx.beginPath();
+        ctx.arc(oreX + 1, oreY - 1, oreSize * 0.4, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+}
+
+// ============================================================================
+// ENHANCED OIL DEPOSIT RENDERING
+// ============================================================================
+
+/**
+ * Draw oil deposit with dark, iridescent surface
+ */
+export function drawEnhancedOilDeposit(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  gridX: number,
+  gridY: number,
+  animTime: number,
+  zoom: number,
+  options: {
+    ambient?: number;
+  } = {}
+): void {
+  const { ambient = 1.0 } = options;
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Dark oil base
+  const oilBaseColor = {
+    r: Math.round(OIL_COLORS.slick.r * ambient),
+    g: Math.round(OIL_COLORS.slick.g * ambient),
+    b: Math.round(OIL_COLORS.slick.b * ambient),
+  };
+
+  ctx.fillStyle = rgb(oilBaseColor);
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.fill();
+
+  // Iridescent oil sheen animation
+  if (zoom >= 0.4) {
+    const sheenPhase = animTime * 0.3;
+    
+    // Create shifting rainbow sheen
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(cx, screenY);
+    ctx.lineTo(screenX + w, cy);
+    ctx.lineTo(cx, screenY + h);
+    ctx.lineTo(screenX, cy);
+    ctx.closePath();
+    ctx.clip();
+    
+    // Multiple sheen layers
+    for (let i = 0; i < 3; i++) {
+      const hash = tileHash(gridX, gridY, i * 7);
+      const sheenOffset = (sheenPhase + hash * Math.PI * 2) % (Math.PI * 2);
+      const sheenX = cx + Math.cos(sheenOffset) * w * 0.3;
+      const sheenY = cy + Math.sin(sheenOffset * 0.5) * h * 0.3;
+      
+      // Rainbow colors cycling
+      const hue = (sheenPhase * 50 + i * 120) % 360;
+      ctx.fillStyle = `hsla(${hue}, 40%, 50%, 0.15)`;
+      ctx.beginPath();
+      ctx.ellipse(sheenX, sheenY, w * 0.2, h * 0.15, sheenOffset, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    
+    ctx.restore();
+  }
+
+  // Bubbles rising animation
+  if (zoom >= 0.5) {
+    const bubblePhase = animTime * 0.5;
+    const numBubbles = 3;
+    
+    for (let i = 0; i < numBubbles; i++) {
+      const hash = tileHash(gridX, gridY, i * 13);
+      const bubbleY = cy + (((bubblePhase * 0.5 + hash) % 1) - 0.5) * h * 0.6;
+      const bubbleX = cx + (hash - 0.5) * w * 0.4;
+      const bubbleSize = 1 + hash * 1.5;
+      
+      ctx.fillStyle = rgb(OIL_COLORS.sheen, 0.4);
+      ctx.beginPath();
+      ctx.arc(bubbleX, bubbleY, bubbleSize, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+}
+
+// ============================================================================
+// ENHANCED SKY BACKGROUND
+// ============================================================================
+
+/**
+ * Draw atmospheric sky with optional clouds
+ */
+export function drawEnhancedSky(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  animTime: number,
+  options: {
+    timeOfDay?: 'dawn' | 'day' | 'dusk' | 'night';
+    clouds?: boolean;
+  } = {}
+): void {
+  const { timeOfDay = 'day', clouds = true } = options;
+  const cloudNoiseFn = getCloudNoise();
+  
+  const width = canvas.width;
+  const height = canvas.height;
+
+  // Sky gradient based on time of day
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  
+  switch (timeOfDay) {
+    case 'dawn':
+      gradient.addColorStop(0, '#1a3a5f');
+      gradient.addColorStop(0.3, '#4a5a7a');
+      gradient.addColorStop(0.6, '#8a6a5a');
+      gradient.addColorStop(0.8, '#d4906a');
+      gradient.addColorStop(1, '#2a4a3a');
+      break;
+    case 'dusk':
+      gradient.addColorStop(0, '#2a2a4a');
+      gradient.addColorStop(0.3, '#5a3a5a');
+      gradient.addColorStop(0.6, '#8a4a4a');
+      gradient.addColorStop(0.8, '#6a3a3a');
+      gradient.addColorStop(1, '#1a2a2a');
+      break;
+    case 'night':
+      gradient.addColorStop(0, '#0a0a1a');
+      gradient.addColorStop(0.5, '#0a1020');
+      gradient.addColorStop(1, '#0a1a15');
+      break;
+    default: // day
+      gradient.addColorStop(0, '#1a3a5f');
+      gradient.addColorStop(0.4, '#2a4a6a');
+      gradient.addColorStop(0.7, '#3a5a7a');
+      gradient.addColorStop(1, '#1a4a2e');
+  }
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  // Clouds for day/dawn/dusk
+  if (clouds && timeOfDay !== 'night') {
+    const cloudPhase = animTime * 0.02;
+    
+    ctx.save();
+    ctx.globalAlpha = timeOfDay === 'dusk' ? 0.2 : 0.15;
+    
+    // Draw several cloud layers
+    for (let layer = 0; layer < 2; layer++) {
+      const layerSpeed = 0.5 + layer * 0.3;
+      const layerScale = 100 + layer * 50;
+      
+      for (let x = -layerScale; x < width + layerScale; x += layerScale) {
+        for (let y = 0; y < height * 0.5; y += layerScale * 0.7) {
+          const cloudVal = cloudNoiseFn(
+            (x + cloudPhase * width * layerSpeed) / (layerScale * 2),
+            y / (layerScale * 2)
+          );
+          
+          if (cloudVal > 0.1) {
+            const cloudSize = (cloudVal + 0.5) * layerScale * 0.8;
+            const cloudAlpha = Math.min(0.4, cloudVal * 0.5);
+            
+            ctx.fillStyle = `rgba(255, 255, 255, ${cloudAlpha})`;
+            ctx.beginPath();
+            ctx.ellipse(x, y, cloudSize, cloudSize * 0.4, 0, 0, Math.PI * 2);
+            ctx.fill();
+          }
+        }
+      }
+    }
+    
+    ctx.restore();
+  }
+
+  // Stars for night
+  if (timeOfDay === 'night') {
+    const starPhase = animTime * 0.1;
+    
+    for (let i = 0; i < 50; i++) {
+      const hash = tileHash(i, i * 7);
+      const hash2 = tileHash(i * 3, i * 11);
+      
+      const starX = hash * width;
+      const starY = hash2 * height * 0.6;
+      const twinkle = Math.sin(starPhase + hash * Math.PI * 10) * 0.3 + 0.7;
+      
+      ctx.fillStyle = `rgba(255, 255, 255, ${twinkle * 0.6})`;
+      ctx.beginPath();
+      ctx.arc(starX, starY, 0.5 + hash * 1, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+}
+
+// ============================================================================
+// UNIT SHADOWS
+// ============================================================================
+
+/**
+ * Draw a soft shadow under a unit
+ */
+export function drawUnitShadow(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  size: number,
+  options: {
+    offsetX?: number;
+    offsetY?: number;
+    blur?: number;
+  } = {}
+): void {
+  const { offsetX = 2, offsetY = 3, blur = 0.3 } = options;
+  
+  const shadowX = screenX + offsetX;
+  const shadowY = screenY + offsetY;
+  
+  ctx.fillStyle = `rgba(0, 0, 0, ${blur})`;
+  ctx.beginPath();
+  ctx.ellipse(shadowX, shadowY, size * 0.8, size * 0.3, 0, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+// ============================================================================
+// SELECTION GLOW EFFECT
+// ============================================================================
+
+/**
+ * Draw a pulsing selection glow around a unit or building
+ */
+export function drawSelectionGlow(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  size: number,
+  animTime: number,
+  color: string = '#22c55e'
+): void {
+  const pulsePhase = animTime * 3;
+  const pulseScale = 1 + Math.sin(pulsePhase) * 0.15;
+  const pulseAlpha = 0.4 + Math.sin(pulsePhase) * 0.2;
+  
+  // Outer glow
+  ctx.strokeStyle = color;
+  ctx.globalAlpha = pulseAlpha * 0.5;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.arc(screenX, screenY, size * pulseScale * 1.2, 0, Math.PI * 2);
+  ctx.stroke();
+  
+  // Inner ring
+  ctx.globalAlpha = pulseAlpha;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(screenX, screenY, size * pulseScale, 0, Math.PI * 2);
+  ctx.stroke();
+  
+  ctx.globalAlpha = 1;
+}
+
+// ============================================================================
+// PARTICLE SYSTEM
+// ============================================================================
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  color: { r: number; g: number; b: number };
+  type: 'smoke' | 'dust' | 'spark' | 'splash';
+}
+
+const particlePools: Map<string, Particle[]> = new Map();
+
+/**
+ * Get or create a particle pool for a specific location
+ */
+function getParticlePool(key: string): Particle[] {
+  if (!particlePools.has(key)) {
+    particlePools.set(key, []);
+  }
+  return particlePools.get(key)!;
+}
+
+/**
+ * Spawn particles at a location
+ */
+export function spawnParticles(
+  key: string,
+  x: number,
+  y: number,
+  type: Particle['type'],
+  count: number
+): void {
+  const pool = getParticlePool(key);
+  
+  for (let i = 0; i < count; i++) {
+    const particle: Particle = {
+      x,
+      y,
+      vx: (Math.random() - 0.5) * 2,
+      vy: type === 'smoke' ? -Math.random() * 2 - 1 : (Math.random() - 0.5) * 3,
+      life: 1,
+      maxLife: 0.5 + Math.random() * 0.5,
+      size: type === 'spark' ? 1 + Math.random() : 2 + Math.random() * 3,
+      color: type === 'smoke' ? { r: 80, g: 80, b: 80 } :
+             type === 'spark' ? { r: 255, g: 200, b: 100 } :
+             type === 'splash' ? { r: 150, g: 180, b: 210 } :
+             { r: 140, g: 120, b: 90 },
+      type,
+    };
+    pool.push(particle);
+  }
+}
+
+/**
+ * Update and draw particles
+ */
+export function updateAndDrawParticles(
+  ctx: CanvasRenderingContext2D,
+  key: string,
+  deltaTime: number
+): void {
+  const pool = getParticlePool(key);
+  
+  for (let i = pool.length - 1; i >= 0; i--) {
+    const p = pool[i];
+    
+    // Update
+    p.x += p.vx * deltaTime * 60;
+    p.y += p.vy * deltaTime * 60;
+    p.life -= deltaTime / p.maxLife;
+    
+    // Gravity for non-smoke particles
+    if (p.type !== 'smoke') {
+      p.vy += 0.1 * deltaTime * 60;
+    }
+    
+    // Remove dead particles
+    if (p.life <= 0) {
+      pool.splice(i, 1);
+      continue;
+    }
+    
+    // Draw
+    const alpha = p.life * 0.6;
+    ctx.fillStyle = rgb(p.color, alpha);
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.size * p.life, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+/**
+ * Clear all particles for a key
+ */
+export function clearParticles(key: string): void {
+  particlePools.delete(key);
+}
+
+// ============================================================================
+// FISHING SPOT RENDERING
+// ============================================================================
+
+/**
+ * Draw fishing spot indicator on water
+ */
+export function drawFishingSpot(
+  ctx: CanvasRenderingContext2D,
+  screenX: number,
+  screenY: number,
+  animTime: number,
+  zoom: number
+): void {
+  const w = TILE_WIDTH;
+  const h = TILE_HEIGHT;
+  const cx = screenX + w / 2;
+  const cy = screenY + h / 2;
+
+  // Fish swimming animation
+  const fishPhase = animTime * 2;
+  
+  ctx.save();
+  
+  // Clip to tile
+  ctx.beginPath();
+  ctx.moveTo(cx, screenY);
+  ctx.lineTo(screenX + w, cy);
+  ctx.lineTo(cx, screenY + h);
+  ctx.lineTo(screenX, cy);
+  ctx.closePath();
+  ctx.clip();
+
+  // Draw a few small fish indicators
+  const numFish = 3;
+  for (let i = 0; i < numFish; i++) {
+    const hash = tileHash(Math.floor(screenX), Math.floor(screenY), i * 7);
+    const fishX = cx + Math.sin(fishPhase + hash * Math.PI * 2) * w * 0.2;
+    const fishY = cy + Math.cos(fishPhase * 0.7 + hash * Math.PI * 3) * h * 0.15;
+    const fishSize = 2 + hash * 2;
+    const fishDir = Math.sin(fishPhase + hash * 10) > 0 ? 1 : -1;
+    
+    // Simple fish shape
+    ctx.fillStyle = 'rgba(150, 180, 200, 0.4)';
+    ctx.beginPath();
+    ctx.ellipse(fishX, fishY, fishSize, fishSize * 0.4, 0, 0, Math.PI * 2);
+    ctx.fill();
+    
+    // Tail
+    ctx.beginPath();
+    ctx.moveTo(fishX - fishSize * fishDir, fishY);
+    ctx.lineTo(fishX - fishSize * 1.5 * fishDir, fishY - fishSize * 0.3);
+    ctx.lineTo(fishX - fishSize * 1.5 * fishDir, fishY + fishSize * 0.3);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  // Ripple effect
+  const ripplePhase = animTime * 1.5;
+  const rippleRadius = 8 + Math.sin(ripplePhase) * 3;
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, rippleRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.restore();
+}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-24b8e7b2-61ce-4166-ba99-98b052a79272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24b8e7b2-61ce-4166-ba99-98b052a79272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enhanced rendering system**
> 
> Adds `src/games/ron/lib/enhancedGraphics.ts` implementing simplex-noise–driven drawing for `grass`, `water` (depth, waves, sparkles), `beach` (foam/gradients), `forest` (wind sway), `mountain` (shading/ore glints), `oil` (iridescent sheen), and `sky` with clouds, plus `drawUnitShadow`, `drawSelectionGlow`, particles, and `drawFishingSpot`. Integrates these into `RoNCanvas` replacing `drawSkyBackground`, `drawGroundTile`, and `drawWaterTile` usages; adds a pre-pass to render unit shadows before units, and renders enhanced beaches and forests. Dependency `simplex-noise` added.
> 
> **Other changes**
> 
> Refines unit visuals in `drawUnits.ts` with muted skin/hair/tool/metal palettes and naval hull color tweak. In `ron-runner` API, narrows to `newState` for action logs (`tick` source) to avoid mismatch when recording recent actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eee869f53a475f91cc316da2e3b0d302fcab76ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->