### PR TITLE
Coaster game command K menu

### DIFF
--- a/src/components/coaster/CommandMenu.tsx
+++ b/src/components/coaster/CommandMenu.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useCoaster } from '@/context/CoasterContext';
+import { Tool, TOOL_INFO, ToolInfo } from '@/games/coaster/types';
+import { useMobile } from '@/hooks/useMobile';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+
+// Global callback to open the command menu
+let openCoasterCommandMenuCallback: (() => void) | null = null;
+
+export function openCoasterCommandMenu() {
+  openCoasterCommandMenuCallback?.();
+}
+
+interface MenuItem {
+  id: string;
+  type: 'tool' | 'panel';
+  tool?: Tool;
+  panel?: 'finances' | 'settings';
+  name: string;
+  description: string;
+  cost?: number;
+  category: string;
+  keywords: string[];
+}
+
+const MENU_CATEGORIES = [
+  { key: 'tools', label: 'Tools' },
+  { key: 'paths', label: 'Paths' },
+  { key: 'terrain', label: 'Terrain' },
+  { key: 'coasters', label: 'Coasters' },
+  { key: 'trees', label: 'Trees' },
+  { key: 'flowers', label: 'Flowers' },
+  { key: 'furniture', label: 'Furniture' },
+  { key: 'fountains', label: 'Fountains' },
+  { key: 'food', label: 'Food & Drink' },
+  { key: 'shops', label: 'Shops & Services' },
+  { key: 'rides_small', label: 'Small Rides' },
+  { key: 'rides_large', label: 'Large Rides' },
+  { key: 'infrastructure', label: 'Infrastructure' },
+  { key: 'panels', label: 'Panels' },
+] as const;
+
+const CATEGORY_LABELS = MENU_CATEGORIES.reduce<Record<string, string>>((acc, category) => {
+  acc[category.key] = category.label;
+  return acc;
+}, {});
+
+// Map coaster type tools to their CoasterType values
+const COASTER_TYPE_TOOL_MAP: Record<string, string> = {
+  coaster_type_wooden_classic: 'wooden_classic',
+  coaster_type_wooden_twister: 'wooden_twister',
+  coaster_type_steel_sit_down: 'steel_sit_down',
+  coaster_type_steel_standup: 'steel_standup',
+  coaster_type_steel_inverted: 'steel_inverted',
+  coaster_type_steel_floorless: 'steel_floorless',
+  coaster_type_steel_wing: 'steel_wing',
+  coaster_type_steel_flying: 'steel_flying',
+  coaster_type_steel_4d: 'steel_4d',
+  coaster_type_steel_spinning: 'steel_spinning',
+  coaster_type_launch_coaster: 'launch_coaster',
+  coaster_type_hyper_coaster: 'hyper_coaster',
+  coaster_type_giga_coaster: 'giga_coaster',
+  coaster_type_water_coaster: 'water_coaster',
+  coaster_type_mine_train: 'mine_train',
+  coaster_type_bobsled: 'bobsled',
+  coaster_type_suspended: 'suspended',
+};
+
+function buildMenuItems(): MenuItem[] {
+  const items: MenuItem[] = [];
+
+  const toolEntries = Object.entries(TOOL_INFO) as [Tool, ToolInfo][];
+  toolEntries.forEach(([tool, info]) => {
+    const categoryLabel = CATEGORY_LABELS[info.category] ?? info.category;
+    const keywords = [
+      info.name.toLowerCase(),
+      tool,
+      info.category,
+      categoryLabel.toLowerCase(),
+    ];
+
+    if (info.category === 'coasters') {
+      keywords.push('coaster', 'track');
+    }
+
+    items.push({
+      id: tool,
+      type: 'tool',
+      tool,
+      name: info.name,
+      description: info.description,
+      cost: info.cost,
+      category: info.category,
+      keywords,
+    });
+  });
+
+  const panels = [
+    {
+      panel: 'finances' as const,
+      name: 'Finances',
+      description: 'Review park finances and income',
+      keywords: ['finances', 'money', 'profit', 'budget', 'cash'],
+    },
+    {
+      panel: 'settings' as const,
+      name: 'Settings',
+      description: 'Update park settings and game tools',
+      keywords: ['settings', 'options', 'preferences', 'export', 'import'],
+    },
+  ];
+
+  panels.forEach(({ panel, name, description, keywords }) => {
+    items.push({
+      id: `panel-${panel}`,
+      type: 'panel',
+      panel,
+      name,
+      description,
+      category: 'panels',
+      keywords,
+    });
+  });
+
+  return items;
+}
+
+const ALL_MENU_ITEMS = buildMenuItems();
+
+export function CoasterCommandMenu() {
+  const { isMobileDevice } = useMobile();
+  const { state, setTool, setActivePanel, startCoasterBuild } = useCoaster();
+  const { finances } = state;
+
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+    setSelectedIndex(0);
+  }, []);
+  
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    setOpen(newOpen);
+    if (newOpen) {
+      setSearch('');
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, []);
+
+  useEffect(() => {
+    openCoasterCommandMenuCallback = () => handleOpenChange(true);
+    return () => {
+      openCoasterCommandMenuCallback = null;
+    };
+  }, [handleOpenChange]);
+
+  const filteredItems = useMemo(() => {
+    if (!search.trim()) return ALL_MENU_ITEMS;
+
+    const searchLower = search.toLowerCase().trim();
+    return ALL_MENU_ITEMS.filter(item => {
+      if (item.name.toLowerCase().includes(searchLower)) return true;
+      if (item.description.toLowerCase().includes(searchLower)) return true;
+      if (item.keywords.some(kw => kw.includes(searchLower))) return true;
+      if (item.category.includes(searchLower)) return true;
+      return false;
+    });
+  }, [search]);
+
+  const groupedItems = useMemo(() => {
+    const groups: Record<string, MenuItem[]> = {};
+    filteredItems.forEach(item => {
+      if (!groups[item.category]) {
+        groups[item.category] = [];
+      }
+      groups[item.category].push(item);
+    });
+    return groups;
+  }, [filteredItems]);
+
+  const flatItems = useMemo(() => {
+    const result: MenuItem[] = [];
+    MENU_CATEGORIES.forEach(cat => {
+      if (groupedItems[cat.key]) {
+        result.push(...groupedItems[cat.key]);
+      }
+    });
+    return result;
+  }, [groupedItems]);
+
+  useEffect(() => {
+    if (isMobileDevice) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen(prev => !prev);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isMobileDevice]);
+
+  const handleSelect = useCallback((item: MenuItem) => {
+    if (item.type === 'tool' && item.tool) {
+      const coasterType = COASTER_TYPE_TOOL_MAP[item.tool];
+      if (coasterType) {
+        startCoasterBuild(coasterType);
+        setTool('coaster_build');
+      } else {
+        setTool(item.tool);
+      }
+    } else if (item.type === 'panel' && item.panel) {
+      setActivePanel(state.activePanel === item.panel ? 'none' : item.panel);
+    }
+    setOpen(false);
+  }, [setTool, setActivePanel, startCoasterBuild, state.activePanel]);
+
+  useEffect(() => {
+    if (!listRef.current || flatItems.length === 0) return;
+    
+    const selectedElement = listRef.current.querySelector(`[data-index="${selectedIndex}"]`);
+    if (selectedElement) {
+      selectedElement.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex, flatItems.length]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        if (flatItems.length === 0) return;
+        e.preventDefault();
+        setSelectedIndex(prev => (prev + 1) % flatItems.length);
+        break;
+      case 'ArrowUp':
+        if (flatItems.length === 0) return;
+        e.preventDefault();
+        setSelectedIndex(prev => (prev - 1 + flatItems.length) % flatItems.length);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (flatItems[selectedIndex]) {
+          handleSelect(flatItems[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        break;
+    }
+  }, [flatItems, selectedIndex, handleSelect]);
+
+  if (isMobileDevice) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent 
+        className="p-0 gap-0 max-w-lg overflow-hidden bg-sidebar border-sidebar-border shadow-2xl"
+        onKeyDown={handleKeyDown}
+      >
+        <VisuallyHidden.Root>
+          <DialogTitle>Command Menu</DialogTitle>
+        </VisuallyHidden.Root>
+        
+        <div className="flex items-center border-b border-sidebar-border px-3">
+          <svg 
+            className="w-4 h-4 text-muted-foreground shrink-0" 
+            fill="none" 
+            viewBox="0 0 24 24" 
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <Input
+            ref={inputRef}
+            value={search}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Search tools, rides, panels..."
+            className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent h-12 text-sm"
+          />
+          <kbd className="hidden sm:inline-flex h-5 select-none items-center gap-1 rounded border border-sidebar-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+            ESC
+          </kbd>
+        </div>
+
+        <ScrollArea className="max-h-[360px]">
+          <div ref={listRef} className="p-2">
+            {flatItems.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">
+                No results found.
+              </div>
+            ) : (
+              MENU_CATEGORIES.map(category => {
+                const items = groupedItems[category.key];
+                if (!items || items.length === 0) return null;
+
+                return (
+                  <div key={category.key} className="mb-2">
+                    <div className="px-2 py-1.5 text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
+                      {category.label}
+                    </div>
+                    <div className="flex flex-col gap-0.5">
+                      {items.map((item) => {
+                        const globalIndex = flatItems.indexOf(item);
+                        const isSelected = globalIndex === selectedIndex;
+                        const canAfford = item.cost === undefined || item.cost === 0 || finances.cash >= item.cost;
+
+                        return (
+                          <button
+                            key={item.id}
+                            data-index={globalIndex}
+                            onClick={() => handleSelect(item)}
+                            disabled={!canAfford}
+                            className={cn(
+                              'flex items-center justify-between gap-2 px-3 py-2 rounded-sm text-sm transition-colors text-left w-full',
+                              isSelected 
+                                ? 'bg-primary text-primary-foreground' 
+                                : 'hover:bg-muted/60',
+                              !canAfford && 'opacity-50 cursor-not-allowed'
+                            )}
+                          >
+                            <div className="flex flex-col gap-0.5 min-w-0">
+                              <span className="font-medium truncate">{item.name}</span>
+                              <span className={cn(
+                                'text-xs truncate',
+                                isSelected ? 'text-primary-foreground/70' : 'text-muted-foreground'
+                              )}>
+                                {item.description}
+                              </span>
+                            </div>
+                            {item.cost !== undefined && item.cost > 0 && (
+                              <span className={cn(
+                                'text-xs shrink-0',
+                                isSelected ? 'text-primary-foreground/70' : 'text-muted-foreground'
+                              )}>
+                                ${item.cost.toLocaleString()}
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </ScrollArea>
+
+        <div className="flex items-center justify-between border-t border-sidebar-border px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center gap-1">
+              <kbd className="inline-flex h-4 items-center rounded border border-sidebar-border bg-muted px-1 font-mono text-[10px]">↑</kbd>
+              <kbd className="inline-flex h-4 items-center rounded border border-sidebar-border bg-muted px-1 font-mono text-[10px]">↓</kbd>
+              <span>navigate</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="inline-flex h-4 items-center rounded border border-sidebar-border bg-muted px-1 font-mono text-[10px]">↵</kbd>
+              <span>select</span>
+            </span>
+          </div>
+          <span className="flex items-center gap-1">
+            <kbd className="inline-flex h-4 items-center rounded border border-sidebar-border bg-muted px-1 font-mono text-[10px]">⌘</kbd>
+            <kbd className="inline-flex h-4 items-center rounded border border-sidebar-border bg-muted px-1 font-mono text-[10px]">K</kbd>
+            <span>to toggle</span>
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/coaster/Game.tsx
+++ b/src/components/coaster/Game.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
 import { MiniMap } from './MiniMap';
 import { Panels } from './panels/Panels';
+import { CoasterCommandMenu } from '@/components/coaster/CommandMenu';
 
 interface GameProps {
   onExit?: () => void;
@@ -85,6 +86,7 @@ export default function CoasterGame({ onExit }: GameProps) {
             <Panels />
           </div>
         </div>
+        <CoasterCommandMenu />
       </div>
     </TooltipProvider>
   );

--- a/src/components/coaster/Sidebar.tsx
+++ b/src/components/coaster/Sidebar.tsx
@@ -7,6 +7,7 @@ import { WEATHER_DISPLAY, WEATHER_EFFECTS } from '@/games/coaster/types/economy'
 import { COASTER_TYPE_STATS, CoasterType, getCoasterCategory } from '@/games/coaster/types/tracks';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { openCoasterCommandMenu } from '@/components/coaster/CommandMenu';
 import {
   Dialog,
   DialogContent,
@@ -619,29 +620,47 @@ export function Sidebar({ onExit }: SidebarProps) {
           <span className="text-sidebar-foreground font-bold tracking-tight">
             ISOCOASTER
           </span>
-          {onExit && (
+          <div className="flex items-center gap-1">
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => setShowExitDialog(true)}
-              title="Exit to Menu"
+              onClick={openCoasterCommandMenu}
+              title="Search (⌘K)"
               className="h-7 w-7 text-muted-foreground hover:text-sidebar-foreground"
             >
-              <svg
-                className="w-4 h-4 -scale-x-100"
-                fill="none"
-                viewBox="0 0 24 24"
+              <svg 
+                className="w-4 h-4" 
+                fill="none" 
+                viewBox="0 0 24 24" 
                 stroke="currentColor"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
             </Button>
-          )}
+            {onExit && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowExitDialog(true)}
+                title="Exit to Menu"
+                className="h-7 w-7 text-muted-foreground hover:text-sidebar-foreground"
+              >
+                <svg
+                  className="w-4 h-4 -scale-x-100"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                  />
+                </svg>
+              </Button>
+            )}
+          </div>
         </div>
       </div>
       


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-046d7897-d6e3-4e2e-82dc-09b2f9d17731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-046d7897-d6e3-4e2e-82dc-09b2f9d17731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a desktop-only `CoasterCommandMenu` (Ctrl/⌘K) that provides a searchable, categorized list of all `TOOL_INFO` actions plus quick links to `Finances`/`Settings`, with keyboard navigation and affordability-based disabling.
> 
> Integrates the menu into `Game.tsx` and adds a new sidebar header search button that opens it via `openCoasterCommandMenu`; selecting coaster type entries triggers `startCoasterBuild` and switches to `coaster_build`.
> 
> **Medium Risk.** Introduces new global keyboard/UI behavior that can affect in-game input handling and tool/panel switching paths, but does not touch auth or persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55d20e3c4e2a7a155b337f5e76873417e76174bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->