### PR TITLE
Iso coaster coop

### DIFF
--- a/src/app/coaster/coop/[roomCode]/page.tsx
+++ b/src/app/coaster/coop/[roomCode]/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { useState, useRef, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { MultiplayerContextProvider } from '@/context/MultiplayerContext';
+import { CoasterProvider, createInitialGameState as createInitialCoasterGameState } from '@/context/CoasterContext';
+import CoasterGame from '@/components/coaster/Game';
+import { CoopModal } from '@/components/multiplayer/CoopModal';
+import { MultiplayerState } from '@/lib/multiplayer/types';
+import { GameState as CoasterGameState } from '@/games/coaster/types';
+import {
+  COASTER_AUTOSAVE_KEY,
+  buildSavedParkMeta,
+  readSavedParksIndex,
+  saveCoasterStateToStorage,
+  upsertSavedParkMeta,
+  writeSavedParksIndex,
+} from '@/games/coaster/saveUtils';
+
+function resolveCoasterState(state?: MultiplayerState): CoasterGameState | null {
+  if (!state || typeof state !== 'object') return null;
+  if ('settings' in state && 'finances' in state && 'coasters' in state) {
+    return state as CoasterGameState;
+  }
+  return null;
+}
+
+export default function CoasterCoopPage() {
+  const params = useParams();
+  const router = useRouter();
+  const roomCode = (params.roomCode as string)?.toUpperCase();
+
+  const [showGame, setShowGame] = useState(false);
+  const [showCoopModal, setShowCoopModal] = useState(true);
+  const [startFreshGame, setStartFreshGame] = useState(false);
+  const isStartingGameRef = useRef(false);
+
+  const handleExitGame = useCallback(() => {
+    router.push('/coaster');
+  }, [router]);
+
+  const handleCoopStart = useCallback((isHost: boolean, initialState?: MultiplayerState, code?: string) => {
+    isStartingGameRef.current = true;
+    const coasterState = resolveCoasterState(initialState);
+
+    if (coasterState) {
+      saveCoasterStateToStorage(COASTER_AUTOSAVE_KEY, coasterState);
+      const meta = buildSavedParkMeta(coasterState, Date.now(), code);
+      const updated = upsertSavedParkMeta(meta, readSavedParksIndex());
+      writeSavedParksIndex(updated);
+      setStartFreshGame(false);
+    } else if (isHost) {
+      setStartFreshGame(true);
+    } else {
+      setStartFreshGame(true);
+    }
+
+    setShowGame(true);
+    setShowCoopModal(false);
+  }, []);
+
+  const handleModalClose = useCallback((open: boolean) => {
+    if (!open && !showGame && !isStartingGameRef.current) {
+      router.push('/coaster');
+    }
+    setShowCoopModal(open);
+  }, [router, showGame]);
+
+  if (showGame) {
+    return (
+      <MultiplayerContextProvider>
+        <CoasterProvider startFresh={startFreshGame}>
+          <main className="h-screen w-screen overflow-hidden">
+            <CoasterGame onExit={handleExitGame} />
+          </main>
+        </CoasterProvider>
+      </MultiplayerContextProvider>
+    );
+  }
+
+  return (
+    <MultiplayerContextProvider>
+      <main className="min-h-screen bg-gradient-to-br from-emerald-950 via-teal-950 to-emerald-950 flex items-center justify-center">
+        <CoopModal
+          open={showCoopModal}
+          onOpenChange={handleModalClose}
+          onStartGame={handleCoopStart}
+          pendingRoomCode={roomCode}
+          basePath="/coaster/coop"
+          homePath="/coaster"
+          defaultRoomName="My Co-op Park"
+          locationLabel="Park"
+          locationLabelLower="park"
+          createInitialState={(name) => createInitialCoasterGameState(name)}
+          applyNameToState={(state, name) => {
+            if (!state || typeof state !== 'object' || !('settings' in state)) return state;
+            const coasterState = state as CoasterGameState;
+            return { ...coasterState, settings: { ...coasterState.settings, name } };
+          }}
+        />
+      </main>
+    </MultiplayerContextProvider>
+  );
+}

--- a/src/components/coaster/Game.tsx
+++ b/src/components/coaster/Game.tsx
@@ -9,6 +9,8 @@ import { TopBar } from './TopBar';
 import { MiniMap } from './MiniMap';
 import { Panels } from './panels/Panels';
 import { CoasterCommandMenu } from '@/components/coaster/CommandMenu';
+import { useCoasterMultiplayerSync } from '@/hooks/useCoasterMultiplayerSync';
+import { CoasterShareModal } from '@/components/multiplayer/CoasterShareModal';
 
 interface GameProps {
   onExit?: () => void;
@@ -16,6 +18,8 @@ interface GameProps {
 
 export default function CoasterGame({ onExit }: GameProps) {
   const { state, isStateReady, setTool, setSpeed } = useCoaster();
+  const { isMultiplayer, playerCount } = useCoasterMultiplayerSync();
+  const [showShareModal, setShowShareModal] = useState(false);
   const [selectedTile, setSelectedTile] = useState<{ x: number; y: number } | null>(null);
   const [viewport, setViewport] = useState<{
     offset: { x: number; y: number };
@@ -64,12 +68,12 @@ export default function CoasterGame({ onExit }: GameProps) {
     <TooltipProvider>
       <div className="w-full h-full min-h-[720px] overflow-hidden bg-background flex">
         {/* Sidebar */}
-        <Sidebar onExit={onExit} />
+        <Sidebar onExit={onExit} onInvite={() => setShowShareModal(true)} />
         
         {/* Main content */}
         <div className="flex-1 flex flex-col ml-56">
           {/* Top bar */}
-          <TopBar />
+          <TopBar isMultiplayer={isMultiplayer} playerCount={playerCount} />
           
           {/* Canvas area */}
           <div className="flex-1 relative overflow-visible">
@@ -92,6 +96,7 @@ export default function CoasterGame({ onExit }: GameProps) {
           </div>
         </div>
         <CoasterCommandMenu />
+        <CoasterShareModal open={showShareModal} onOpenChange={setShowShareModal} />
       </div>
     </TooltipProvider>
   );

--- a/src/components/coaster/Sidebar.tsx
+++ b/src/components/coaster/Sidebar.tsx
@@ -8,6 +8,7 @@ import { COASTER_TYPE_STATS, CoasterType, getCoasterCategory } from '@/games/coa
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { openCoasterCommandMenu } from '@/components/coaster/CommandMenu';
+import { Users } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -564,6 +565,7 @@ function ExitDialog({
 
 interface SidebarProps {
   onExit?: () => void;
+  onInvite?: () => void;
 }
 
 // Map coaster type tools to their CoasterType values
@@ -612,7 +614,7 @@ const COASTER_TYPE_PRIMARY_COLORS: Record<string, string> = {
   suspended: '#b45309',
 };
 
-export function Sidebar({ onExit }: SidebarProps) {
+export function Sidebar({ onExit, onInvite }: SidebarProps) {
   const { state, setTool, saveGame, startCoasterBuild, cancelCoasterBuild } = useCoaster();
   const { selectedTool, finances, weather, buildingCoasterType } = state;
   const [showExitDialog, setShowExitDialog] = useState(false);
@@ -666,6 +668,17 @@ export function Sidebar({ onExit }: SidebarProps) {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
             </Button>
+            {onInvite && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onInvite}
+                title="Invite Players"
+                className="h-7 w-7 text-muted-foreground hover:text-sidebar-foreground"
+              >
+                <Users className="w-4 h-4" />
+              </Button>
+            )}
             {onExit && (
               <Button
                 variant="ghost"

--- a/src/components/coaster/TopBar.tsx
+++ b/src/components/coaster/TopBar.tsx
@@ -46,7 +46,12 @@ function SuperFastIcon() {
 // TOPBAR COMPONENT
 // =============================================================================
 
-export function TopBar() {
+interface TopBarProps {
+  isMultiplayer?: boolean;
+  playerCount?: number;
+}
+
+export function TopBar({ isMultiplayer = false, playerCount = 0 }: TopBarProps) {
   const { state, setSpeed, setActivePanel, setParkSettings } = useCoaster();
   const { settings, stats, finances, year, month, day, hour, minute, speed } = state;
   
@@ -157,6 +162,12 @@ export function TopBar() {
       
       {/* Spacer */}
       <div className="flex-1" />
+
+      {isMultiplayer && (
+        <div className="px-2 py-1 text-xs text-slate-300 bg-slate-800/80 rounded-md">
+          Co-op: {playerCount} player{playerCount === 1 ? '' : 's'}
+        </div>
+      )}
       
       {/* Panel buttons */}
       <div className="flex items-center gap-2">

--- a/src/components/multiplayer/CoasterShareModal.tsx
+++ b/src/components/multiplayer/CoasterShareModal.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useMultiplayer } from '@/context/MultiplayerContext';
+import { useCoaster } from '@/context/CoasterContext';
+import { Copy, Check, Loader2 } from 'lucide-react';
+
+interface CoasterShareModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  basePath?: string;
+}
+
+export function CoasterShareModal({ open, onOpenChange, basePath }: CoasterShareModalProps) {
+  const [copied, setCopied] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const { roomCode, createRoom } = useMultiplayer();
+  const { state, isStateReady } = useCoaster();
+  const coopBasePath = (basePath ?? '/coaster/coop').replace(/\/$/, '');
+
+  useEffect(() => {
+    if (open && !roomCode && !isCreating && isStateReady) {
+      setIsCreating(true);
+      createRoom(state.settings.name, state)
+        .then((code) => {
+          window.history.replaceState({}, '', `${coopBasePath}/${code}`);
+        })
+        .catch((err) => {
+          console.error('[CoasterShareModal] Failed to create room:', err);
+        })
+        .finally(() => {
+          setIsCreating(false);
+        });
+    }
+  }, [open, roomCode, isCreating, isStateReady, createRoom, state, coopBasePath]);
+
+  useEffect(() => {
+    if (!open) {
+      setCopied(false);
+    }
+  }, [open]);
+
+  const handleCopyLink = () => {
+    if (!roomCode) return;
+    const url = `${window.location.origin}${coopBasePath}/${roomCode}`;
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const inviteUrl = roomCode ? `${window.location.origin}${coopBasePath}/${roomCode}` : '';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md bg-slate-900 border-slate-700 text-white overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="text-white">
+            Invite Players
+          </DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Share this link with friends to build a park together
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4 overflow-hidden">
+          {isCreating || !roomCode ? (
+            <div className="flex items-center justify-center gap-2 py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+              <span className="text-slate-400">Creating co-op session...</span>
+            </div>
+          ) : (
+            <>
+              <div className="text-center">
+                <div className="text-4xl font-mono font-bold tracking-widest text-white mb-2">
+                  {roomCode}
+                </div>
+                <div className="text-sm text-slate-400">Invite Code</div>
+              </div>
+
+              <div className="space-y-2 overflow-hidden">
+                <div className="w-full bg-slate-800 rounded-lg px-4 py-3 text-sm text-slate-300 truncate">
+                  {inviteUrl}
+                </div>
+                <Button
+                  onClick={handleCopyLink}
+                  variant="outline"
+                  className="w-full border-slate-600 hover:bg-slate-700"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="w-4 h-4 mr-2 text-green-400" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-4 h-4 mr-2" />
+                      Copy Invite Link
+                    </>
+                  )}
+                </Button>
+              </div>
+
+              <Button
+                onClick={() => onOpenChange(false)}
+                className="w-full bg-slate-700 hover:bg-slate-600 text-white border border-slate-600"
+              >
+                Close
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/context/CoasterContext.tsx
+++ b/src/context/CoasterContext.tsx
@@ -350,7 +350,7 @@ function findStationTile(
   return trackTiles[0];
 }
 
-function createInitialGameState(parkName: string = 'My Theme Park', gridSize: number = DEFAULT_GRID_SIZE): GameState {
+export function createInitialGameState(parkName: string = 'My Theme Park', gridSize: number = DEFAULT_GRID_SIZE): GameState {
   // Create empty grid
   const grid: Tile[][] = [];
   for (let y = 0; y < gridSize; y++) {

--- a/src/context/MultiplayerContext.tsx
+++ b/src/context/MultiplayerContext.tsx
@@ -18,8 +18,8 @@ import {
   Player,
   ConnectionState,
   RoomData,
+  MultiplayerState,
 } from '@/lib/multiplayer/types';
-import { GameState } from '@/types/game';
 import { useGT } from 'gt-next';
 
 // Generate a random 5-character room code
@@ -40,7 +40,7 @@ interface MultiplayerContextValue {
   error: string | null;
 
   // Actions
-  createRoom: (cityName: string, initialState: GameState) => Promise<string>;
+  createRoom: (cityName: string, initialState: MultiplayerState) => Promise<string>;
   joinRoom: (roomCode: string) => Promise<RoomData>;
   leaveRoom: () => void;
   
@@ -48,14 +48,14 @@ interface MultiplayerContextValue {
   dispatchAction: (action: GameActionInput) => void;
   
   // Initial state for new players
-  initialState: GameState | null;
+  initialState: MultiplayerState | null;
   
   // Callback for when remote actions are received
   onRemoteAction: ((action: GameAction) => void) | null;
   setOnRemoteAction: (callback: ((action: GameAction) => void) | null) => void;
   
   // Update the game state (any player can do this now)
-  updateGameState: (state: GameState) => void;
+  updateGameState: (state: MultiplayerState) => void;
   
   // Provider instance (for advanced usage)
   provider: MultiplayerProvider | null;
@@ -76,7 +76,7 @@ export function MultiplayerContextProvider({
   const [roomCode, setRoomCode] = useState<string | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [initialState, setInitialState] = useState<GameState | null>(null);
+  const [initialState, setInitialState] = useState<MultiplayerState | null>(null);
   const [provider, setProvider] = useState<MultiplayerProvider | null>(null);
   const [onRemoteAction, setOnRemoteAction] = useState<((action: GameAction) => void) | null>(null);
 
@@ -94,7 +94,7 @@ export function MultiplayerContextProvider({
 
   // Create a room (first player to start a session)
   const createRoom = useCallback(
-    async (cityName: string, gameState: GameState): Promise<string> => {
+    async (cityName: string, gameState: MultiplayerState): Promise<string> => {
       setConnectionState('connecting');
       setError(null);
 
@@ -226,7 +226,7 @@ export function MultiplayerContextProvider({
 
   // Update the game state (any player can do this)
   const updateGameState = useCallback(
-    (state: GameState) => {
+    (state: MultiplayerState) => {
       if (providerRef.current) {
         providerRef.current.updateGameState(state);
       }

--- a/src/games/coaster/saveUtils.ts
+++ b/src/games/coaster/saveUtils.ts
@@ -17,9 +17,10 @@ export type SavedParkMeta = {
   month: number;
   day: number;
   savedAt: number;
+  roomCode?: string;
 };
 
-export function buildSavedParkMeta(state: GameState, savedAt: number = Date.now()): SavedParkMeta {
+export function buildSavedParkMeta(state: GameState, savedAt: number = Date.now(), roomCode?: string): SavedParkMeta {
   return {
     id: state.id,
     name: state.settings?.name ?? 'Unnamed Park',
@@ -31,6 +32,7 @@ export function buildSavedParkMeta(state: GameState, savedAt: number = Date.now(
     month: state.month ?? 1,
     day: state.day ?? 1,
     savedAt,
+    roomCode,
   };
 }
 
@@ -59,7 +61,12 @@ export function upsertSavedParkMeta(meta: SavedParkMeta, parks?: SavedParkMeta[]
   const list = parks ? [...parks] : readSavedParksIndex();
   const existingIndex = list.findIndex((park) => park.id === meta.id);
   if (existingIndex >= 0) {
-    list[existingIndex] = meta;
+    const existing = list[existingIndex];
+    list[existingIndex] = {
+      ...existing,
+      ...meta,
+      roomCode: meta.roomCode ?? existing.roomCode,
+    };
   } else {
     list.push(meta);
   }

--- a/src/hooks/useCoasterMultiplayerSync.ts
+++ b/src/hooks/useCoasterMultiplayerSync.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useMultiplayerOptional } from '@/context/MultiplayerContext';
+import { useCoaster } from '@/context/CoasterContext';
+import { GameAction, MultiplayerState } from '@/lib/multiplayer/types';
+import { GameState as CoasterGameState } from '@/games/coaster/types';
+
+const SYNC_INTERVAL_MS = 2000;
+const SUPPRESS_BROADCAST_MS = 750;
+
+function isCoasterState(state: MultiplayerState): state is CoasterGameState {
+  if (!state || typeof state !== 'object') return false;
+  return 'settings' in state && 'finances' in state && 'coasters' in state;
+}
+
+export function useCoasterMultiplayerSync() {
+  const multiplayer = useMultiplayerOptional();
+  const coaster = useCoaster();
+  const lastBroadcastRef = useRef(0);
+  const lastRemoteTimestampRef = useRef(0);
+  const suppressBroadcastUntilRef = useRef(0);
+
+  useEffect(() => {
+    if (!multiplayer) return;
+
+    const handleRemoteAction = (action: GameAction) => {
+      if (action.type !== 'fullState') return;
+      if (!isCoasterState(action.state)) return;
+      if (action.timestamp <= lastRemoteTimestampRef.current) return;
+
+      lastRemoteTimestampRef.current = action.timestamp;
+      suppressBroadcastUntilRef.current = Date.now() + SUPPRESS_BROADCAST_MS;
+      coaster.loadState(JSON.stringify(action.state));
+    };
+
+    multiplayer.setOnRemoteAction(handleRemoteAction);
+    return () => multiplayer.setOnRemoteAction(null);
+  }, [multiplayer, coaster]);
+
+  useEffect(() => {
+    if (!multiplayer || multiplayer.connectionState !== 'connected') return;
+    if (!coaster.isStateReady) return;
+
+    const now = Date.now();
+    if (now < suppressBroadcastUntilRef.current) return;
+    if (now - lastBroadcastRef.current < SYNC_INTERVAL_MS) return;
+    lastBroadcastRef.current = now;
+
+    const state = coaster.latestStateRef.current;
+    multiplayer.dispatchAction({ type: 'fullState', state });
+    multiplayer.updateGameState(state);
+  }, [multiplayer, coaster.state, coaster.isStateReady, coaster.latestStateRef]);
+
+  return {
+    isMultiplayer: multiplayer?.connectionState === 'connected',
+    playerCount: multiplayer?.players.length ?? 0,
+    roomCode: multiplayer?.roomCode ?? null,
+    connectionState: multiplayer?.connectionState ?? 'disconnected',
+    players: multiplayer?.players ?? [],
+    leaveRoom: multiplayer?.leaveRoom ?? (() => {}),
+  };
+}

--- a/src/lib/multiplayer/database.ts
+++ b/src/lib/multiplayer/database.ts
@@ -34,7 +34,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
-import { GameState } from '@/types/game';
+import { MultiplayerState } from '@/lib/multiplayer/types';
 import { serializeAndCompressForDBAsync } from '@/lib/saveWorkerManager';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -91,7 +91,7 @@ export interface GameRoomRow {
 export async function createGameRoom(
   roomCode: string,
   cityName: string,
-  gameState: GameState
+  gameState: MultiplayerState
 ): Promise<boolean> {
   if (!supabase) return false;
   try {
@@ -131,7 +131,7 @@ export async function createGameRoom(
  */
 export async function loadGameRoom(
   roomCode: string
-): Promise<{ gameState: GameState; cityName: string } | null> {
+): Promise<{ gameState: MultiplayerState; cityName: string } | null> {
   if (!supabase) return null;
   try {
     const { data, error } = await supabase
@@ -151,7 +151,7 @@ export async function loadGameRoom(
       return null;
     }
 
-    const gameState = JSON.parse(decompressed) as GameState;
+    const gameState = JSON.parse(decompressed) as MultiplayerState;
     return { gameState, cityName: data.city_name };
   } catch (e) {
     console.error('[Database] Error loading room:', e);
@@ -166,7 +166,7 @@ export async function loadGameRoom(
  */
 export async function updateGameRoom(
   roomCode: string,
-  gameState: GameState
+  gameState: MultiplayerState
 ): Promise<boolean> {
   if (!supabase) return false;
   try {

--- a/src/lib/multiplayer/supabaseProvider.ts
+++ b/src/lib/multiplayer/supabaseProvider.ts
@@ -8,6 +8,7 @@ import {
   generatePlayerId,
   generatePlayerColor,
   generatePlayerName,
+  MultiplayerState,
 } from './types';
 import {
   createGameRoom,
@@ -16,7 +17,6 @@ import {
   updatePlayerCount,
   CitySizeLimitError,
 } from './database';
-import { GameState } from '@/types/game';
 import { msg } from 'gt-next';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -34,11 +34,11 @@ export interface MultiplayerProviderOptions {
   roomCode: string;
   cityName: string;
   playerName?: string; // Optional - auto-generated if not provided
-  initialGameState?: GameState; // If provided, this player is creating the room
+  initialGameState?: MultiplayerState; // If provided, this player is creating the room
   onConnectionChange?: (connected: boolean, peerCount: number) => void;
   onPlayersChange?: (players: Player[]) => void;
   onAction?: (action: GameAction) => void;
-  onStateReceived?: (state: GameState) => void;
+  onStateReceived?: (state: MultiplayerState) => void;
   onError?: (error: string) => void;
 }
 
@@ -51,13 +51,13 @@ export class MultiplayerProvider {
   private player: Player;
   private options: MultiplayerProviderOptions;
   private players: Map<string, Player> = new Map();
-  private gameState: GameState | null = null;
+  private gameState: MultiplayerState | null = null;
   private destroyed = false;
   private hasReceivedInitialState = false; // Prevent multiple state-sync overwrites
   
   // State save throttling
   private lastStateSave = 0;
-  private pendingStateSave: GameState | null = null;
+  private pendingStateSave: MultiplayerState | null = null;
   private saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: MultiplayerProviderOptions) {
@@ -202,7 +202,7 @@ export class MultiplayerProvider {
       })
       // Broadcast: state sync from existing players (for new joiners)
       .on('broadcast', { event: 'state-sync' }, ({ payload }) => {
-        const { state, to, from } = payload as { state: GameState; to: string; from: string };
+        const { state, to, from } = payload as { state: MultiplayerState; to: string; from: string };
         // Only process if:
         // 1. It's meant for us
         // 2. We're NOT the creator (creators have the canonical state, should never be overwritten)
@@ -250,7 +250,7 @@ export class MultiplayerProvider {
   /**
    * Update the game state and save to database (throttled)
    */
-  updateGameState(state: GameState): void {
+  updateGameState(state: MultiplayerState): void {
     this.gameState = state;
     
     const now = Date.now();
@@ -275,7 +275,7 @@ export class MultiplayerProvider {
     }
   }
 
-  private saveStateToDatabase(state: GameState): void {
+  private saveStateToDatabase(state: MultiplayerState): void {
     this.lastStateSave = Date.now();
     updateGameRoom(this.roomCode, state).catch((e) => {
       if (e instanceof CitySizeLimitError) {

--- a/src/lib/multiplayer/types.ts
+++ b/src/lib/multiplayer/types.ts
@@ -1,6 +1,9 @@
 // Multiplayer types for co-op gameplay
 
-import { Tool, GameState, Budget } from '@/types/game';
+import type { Tool, Budget, GameState as IsoCityGameState } from '@/types/game';
+import type { GameState as CoasterGameState } from '@/games/coaster/types';
+
+export type MultiplayerState = IsoCityGameState | CoasterGameState;
 
 // Base action properties
 interface BaseAction {
@@ -18,7 +21,7 @@ export type GameAction =
   | (BaseAction & { type: 'setSpeed'; speed: 0 | 1 | 2 | 3 })
   | (BaseAction & { type: 'setDisasters'; enabled: boolean })
   | (BaseAction & { type: 'createBridges'; pathTiles: Array<{ x: number; y: number }>; trackType: 'road' | 'rail' })
-  | (BaseAction & { type: 'fullState'; state: GameState })
+  | (BaseAction & { type: 'fullState'; state: MultiplayerState })
   | (BaseAction & { type: 'tick'; tickData: TickData });
 
 // Action input types (without timestamp and playerId, which are added automatically)
@@ -30,7 +33,7 @@ export type SetBudgetAction = { type: 'setBudget'; key: keyof Budget; funding: n
 export type SetSpeedAction = { type: 'setSpeed'; speed: 0 | 1 | 2 | 3 };
 export type SetDisastersAction = { type: 'setDisasters'; enabled: boolean };
 export type CreateBridgesAction = { type: 'createBridges'; pathTiles: Array<{ x: number; y: number }>; trackType: 'road' | 'rail' };
-export type FullStateAction = { type: 'fullState'; state: GameState };
+export type FullStateAction = { type: 'fullState'; state: MultiplayerState };
 export type TickAction = { type: 'tick'; tickData: TickData };
 
 export type GameActionInput = 
@@ -52,12 +55,12 @@ export interface TickData {
   day: number;
   hour: number;
   tick: number;
-  stats: GameState['stats'];
+  stats: IsoCityGameState['stats'];
   // Only send changed tiles to minimize bandwidth
   changedTiles?: Array<{
     x: number;
     y: number;
-    tile: GameState['grid'][0][0];
+    tile: IsoCityGameState['grid'][0][0];
   }>;
 }
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-67d79cba-d967-45b1-8ff9-575b63ad8e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67d79cba-d967-45b1-8ff9-575b63ad8e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds co-op multiplayer support to IsoCoaster, including a dedicated `/coaster/coop/[roomCode]` entry page and a `CoopModal` flow from the coaster landing page (with saved parks able to resume into their associated room).
> 
> Introduces park invite/sharing UX in-game via `CoasterShareModal`, a new `useCoasterMultiplayerSync` hook that periodically broadcasts/loads `fullState`, and TopBar/Sidebar indicators/actions for co-op sessions.
> 
> Generalizes multiplayer plumbing across IsoCity + IsoCoaster by defining a shared `MultiplayerState` union, updating `MultiplayerContext`, Supabase provider/DB functions, and `CoopModal` to accept game-specific labels/paths and state creation/name-application. Saved coaster metadata now stores optional `roomCode`.
> 
> **High Risk.** Touches core multiplayer state types and Supabase persistence paths, and adds periodic full-state sync for co-op sessions; regressions could affect existing IsoCity co-op behavior and state loading/saving.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9fbdc0a3f94fa0b4cb7ec42ca829220d269ac03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->