### PR TITLE
Iso coaster mobile map panning

### DIFF
--- a/src/components/coaster/CoasterGrid.tsx
+++ b/src/components/coaster/CoasterGrid.tsx
@@ -2545,6 +2545,7 @@ export function CoasterGrid({
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+  const isTouchDraggingRef = useRef(false);
   const initialPinchDistanceRef = useRef<number | null>(null);
   const initialZoomRef = useRef(1);
   const lastTouchCenterRef = useRef<{ x: number; y: number } | null>(null);
@@ -3369,6 +3370,7 @@ const tile = grid[y][x];
       const touch = e.touches[0];
       touchStartRef.current = { x: touch.clientX, y: touch.clientY, time: Date.now() };
       setDragStart({ x: touch.clientX - offset.x, y: touch.clientY - offset.y });
+      isTouchDraggingRef.current = true;
       setIsDragging(true);
       initialPinchDistanceRef.current = null;
       lastTouchCenterRef.current = null;
@@ -3377,6 +3379,7 @@ const tile = grid[y][x];
       initialPinchDistanceRef.current = distance;
       initialZoomRef.current = zoom;
       lastTouchCenterRef.current = getTouchCenter(e.touches[0], e.touches[1]);
+      isTouchDraggingRef.current = false;
       setIsDragging(false);
     }
   }, [offset, zoom, getTouchDistance, getTouchCenter]);
@@ -3384,7 +3387,7 @@ const tile = grid[y][x];
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     e.preventDefault();
 
-    if (e.touches.length === 1 && isDragging && !initialPinchDistanceRef.current) {
+    if (e.touches.length === 1 && isTouchDraggingRef.current && !initialPinchDistanceRef.current) {
       const touch = e.touches[0];
       setOffset({
         x: touch.clientX - dragStart.x,
@@ -3415,7 +3418,7 @@ const tile = grid[y][x];
         lastTouchCenterRef.current = currentCenter;
       }
     }
-  }, [isDragging, dragStart, zoom, offset, getTouchDistance, getTouchCenter]);
+  }, [dragStart, zoom, offset, getTouchDistance, getTouchCenter]);
 
   const handleTouchEnd = useCallback((e: React.TouchEvent) => {
     const touchStart = touchStartRef.current;
@@ -3454,12 +3457,14 @@ const tile = grid[y][x];
       }
 
       setIsDragging(false);
+      isTouchDraggingRef.current = false;
       touchStartRef.current = null;
       initialPinchDistanceRef.current = null;
       lastTouchCenterRef.current = null;
     } else if (e.touches.length === 1) {
       const touch = e.touches[0];
       setDragStart({ x: touch.clientX - offset.x, y: touch.clientY - offset.y });
+      isTouchDraggingRef.current = true;
       setIsDragging(true);
       initialPinchDistanceRef.current = null;
       lastTouchCenterRef.current = null;


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-56940446-0089-4331-bcef-98a577d4480a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56940446-0089-4331-bcef-98a577d4480a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds **mobile touch controls** to `CoasterGrid` for viewport interaction. Supports *one-finger panning*, *two-finger pinch-to-zoom with center-based zooming and panning*, and a *tap-to-interact* gesture that selects, places, or bulldozes tiles based on `selectedTool`.
> 
> The container now uses `touch-none` and wires `onTouchStart`/`onTouchMove`/`onTouchEnd`/`onTouchCancel` handlers; touch state is tracked via refs to distinguish taps vs drags and manage pinch state.
> 
> **Medium Risk.** Changes core input handling for the grid viewport and tile interactions; regressions could impact mobile gesture behavior and interaction accuracy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7c3f539534596de682597e88209bb1ea135af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->