### PR TITLE
Change coaster station size from 2x1 to 1x1

### DIFF
--- a/src/games/coaster/types/game.ts
+++ b/src/games/coaster/types/game.ts
@@ -176,7 +176,7 @@ export const TOOL_INFO: Record<Tool, ToolInfo> = {
   coaster_slope_up: { name: 'Track: Slope Up', cost: 30, description: 'Place a rising track segment', category: 'coasters' },
   coaster_slope_down: { name: 'Track: Slope Down', cost: 30, description: 'Place a descending track segment', category: 'coasters' },
   coaster_loop: { name: 'Track: Loop', cost: 150, description: 'Place a vertical loop element', category: 'coasters' },
-  coaster_station: { name: 'Coaster Station', cost: 500, description: 'Place coaster station', category: 'coasters', size: { width: 2, height: 1 } },
+  coaster_station: { name: 'Coaster Station', cost: 500, description: 'Place coaster station', category: 'coasters', size: { width: 1, height: 1 } },
   
   // Wooden Coasters
   coaster_type_wooden_classic: { name: 'Classic Wooden', cost: 50, description: 'Traditional wooden coaster with airtime hills', category: 'coasters' },


### PR DESCRIPTION
## Summary
- Makes the coaster station footprint smaller (1x1 instead of 2x1) for more flexible placement

## Test plan
- Build a coaster station in the game and verify it occupies a single tile

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `TOOL_INFO` so the `coaster_station` tool footprint is **1x1** instead of **2x1**, affecting how coaster stations occupy tiles during placement.
> 
> **Low Risk.** Single constant change to the `coaster_station` tool size; main risk is placement/overlap behavior differing from prior expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e81e37f603419bdc9037b0d3a80b940a3997152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->