### PR TITLE
New park terrain lakes

### DIFF
--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -51,7 +51,7 @@ function isStarterBuilding(x: number, y: number, buildingType: string): boolean 
   return false;
 }
 
-// Perlin-like noise for terrain generation
+// Perlin-like noise for terrain generation (exported for reuse in other games)
 function noise2D(x: number, y: number, seed: number = 42): number {
   const n = Math.sin(x * 12.9898 + y * 78.233 + seed) * 43758.5453123;
   return n - Math.floor(n);
@@ -83,7 +83,7 @@ function interpolatedNoise(x: number, y: number, seed: number): number {
   return i1 * (1 - fracY) + i2 * fracY;
 }
 
-function perlinNoise(x: number, y: number, seed: number, octaves: number = 4): number {
+export function perlinNoise(x: number, y: number, seed: number, octaves: number = 4): number {
   let total = 0;
   let frequency = 0.05;
   let amplitude = 1;


### PR DESCRIPTION
Add procedural lake generation to new IsoCoaster parks to match IsoCity's random terrain features.

The previous implementation for IsoCoaster parks only generated a single, fixed circular lake. This change introduces Perlin-like noise functions and a radial expansion algorithm to create 2-3 organically shaped lakes at random positions, enhancing terrain variety.

---
<a href="https://cursor.com/background-agent?bcId=bc-49d58cc7-dfdb-4681-9a8c-b949ed8e4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49d58cc7-dfdb-4681-9a8c-b949ed8e4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds procedural lake generation when creating a new coaster park: the initial grid now calls `generateLakes` to place **2–3 randomly positioned, larger water bodies** using a Perlin-noise-based center selection and radial expansion, replacing the prior fixed circular corner lake.
> 
> Exports `perlinNoise` from `src/lib/simulation.ts` and reuses it in `CoasterContext.tsx` for terrain generation.
> 
> **Low Risk.** Affects only new-game terrain initialization and exports a utility; primary risk is unintended lake placement/performance impact during park creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad72890ac703766916652f0e5102dfa0dc6a125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->