### PR TITLE
Iso-city road display issues

### DIFF
--- a/src/components/game/roadDrawing.ts
+++ b/src/components/game/roadDrawing.ts
@@ -79,9 +79,10 @@ export function drawRoad(
   const mergeInfo = getMergeInfo(gridX, gridY);
   
   // Calculate base road width based on road type
-  const laneWidthRatio = mergeInfo.type === 'highway' ? 0.22 :
-                        mergeInfo.type === 'avenue' ? 0.20 :
-                        0.18;
+  // Using narrower widths to ensure sidewalks remain visible on tile edges
+  const laneWidthRatio = mergeInfo.type === 'highway' ? 0.16 :
+                        mergeInfo.type === 'avenue' ? 0.15 :
+                        0.14;
   const roadW = w * laneWidthRatio;
   
   // Sidewalk configuration
@@ -89,8 +90,8 @@ export function drawRoad(
   const sidewalkColor = ROAD_COLORS.SIDEWALK;
   const curbColor = ROAD_COLORS.CURB;
   
-  // Edge stop distance - extend past edge (>1.0) to ensure overlap and flush alignment at tile boundaries
-  const edgeStop = 1.15;
+  // Edge stop distance - keep at or below 1.0 to avoid road surfaces overlapping adjacent tile sidewalks
+  const edgeStop = 0.98;
   
   // Calculate edge midpoints
   const northEdgeX = x + w * 0.25;
@@ -327,8 +328,8 @@ export function drawRoad(
     ctx.fill();
   }
   
-  // Center intersection - larger size to ensure full coverage at turns
-  const centerSize = roadW * 1.6;
+  // Center intersection
+  const centerSize = roadW * 1.4;
   ctx.beginPath();
   ctx.moveTo(cx, cy - centerSize);
   ctx.lineTo(cx + centerSize, cy);


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-01e85000-9b05-4ef8-a200-46da69c58633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01e85000-9b05-4ef8-a200-46da69c58633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `drawRoad` geometry in `roadDrawing.ts` to better preserve sidewalk visibility by narrowing lane/road widths across road types.
> 
> Reduces how far road segments extend toward tile edges (`edgeStop`) and slightly shrinks the center intersection fill to avoid overdraw/overlap around adjacent tiles and turns.
> 
> **Low Risk.** Small, localized canvas rendering tweaks with no changes to game state, networking, or data handling; main risk is minor visual regressions in road alignment at different zoom levels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83c544d978eb7b0adfb581050bdb063c879cc655. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->