### PR TITLE
Water playground asset offset

### DIFF
--- a/src/games/coaster/lib/coasterRenderConfig.ts
+++ b/src/games/coaster/lib/coasterRenderConfig.ts
@@ -348,7 +348,7 @@ const RIDES_SMALL_SHEET: SpriteSheet = {
     { name: 'ride_bumper_boats', row: 4, col: 0, offsetY: 80, scale: 0.52 }, // 3x2
     { name: 'ride_paddle_boats', row: 4, col: 1, offsetY: 80, scale: 0.5 }, // 3x2
     { name: 'ride_lazy_river', row: 4, col: 2, offsetY: 80, scale: 0.55 }, // 3x2
-    { name: 'ride_water_play', row: 4, col: 3, offsetY: 100, scale: 0.65 }, // 3x3
+    { name: 'ride_water_play', row: 4, col: 3, offsetY: 200, scale: 0.65 }, // 3x3 (down one tile)
     { name: 'ride_splash_zone', row: 4, col: 4, offsetY: 70, scale: 0.55 }, // 2x2
     // Row 5: Dark rides (3x3 buildings - large dark ride buildings)
     { name: 'ride_haunted_house', row: 5, col: 0, offsetY: 100, scale: 0.85 },


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-82287758-7fbf-447c-839f-b4f397af5eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82287758-7fbf-447c-839f-b4f397af5eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single render-config constant change affecting only the on-screen placement of one sprite; no logic, data, or security impact.
> 
> **Overview**
> Adjusts sprite alignment for the `ride_water_play` (water playground) asset in `coasterRenderConfig.ts` by increasing its `offsetY` from `100` to `200` so it renders one tile lower (comment updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60f7e11b493d29aa30744c26b8430830323b63f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->