### PR TITLE
Add keyboard shortcuts for tools (V,B,R,L,U,1,2,3,X,O,G)

### DIFF
--- a/src/components/game/Sidebar.tsx
+++ b/src/components/game/Sidebar.tsx
@@ -242,7 +242,7 @@ const HoverSubmenu = React.memo(function HoverSubmenu({
                   }`}
                   title={`${m(info.description)} - Cost: $${info.cost.toLocaleString()}`}
                 >
-                  <span className="flex-1 text-left truncate">{m(info.name)}</span>
+                  <span className="flex-1 text-left truncate">{info.shortcut ? `(${info.shortcut}) ` : ''}{m(info.name)}</span>
                   <span className={`text-xs ${isSelected ? 'opacity-80' : 'opacity-50'}`}>${info.cost.toLocaleString()}</span>
                 </Button>
               );
@@ -648,7 +648,7 @@ export const Sidebar = React.memo(function Sidebar({ onExit }: { onExit?: () => 
                     }`}
                     title={`${m(info.description)}${info.cost > 0 ? ` - Cost: $${info.cost}` : ''}`}
                   >
-                    <span className="flex-1 text-left truncate">{m(info.name)}</span>
+                    <span className="flex-1 text-left truncate">{info.shortcut ? `(${info.shortcut}) ` : ''}{m(info.name)}</span>
                     {info.cost > 0 && (
                       <span className="text-xs opacity-60">${info.cost}</span>
                     )}

--- a/src/components/ui/CommandMenu.tsx
+++ b/src/components/ui/CommandMenu.tsx
@@ -28,6 +28,7 @@ interface MenuItem {
   name: unknown; // Raw message object from msg()
   description: unknown; // Raw message object from msg()
   cost?: number;
+  shortcut?: string; // Keyboard shortcut from TOOL_INFO
   category: string;
   keywords: string[];
 }
@@ -61,6 +62,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'tools',
       keywords: [info.name.toLowerCase(), tool, 'tool', 'infrastructure'],
     });
@@ -77,6 +79,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'zones',
       keywords: [info.name.toLowerCase(), tool, 'zone'],
     });
@@ -101,6 +104,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'zoning',
       keywords,
     });
@@ -117,6 +121,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'services',
       keywords: [info.name.toLowerCase(), tool, 'service', 'building'],
     });
@@ -133,6 +138,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'parks',
       keywords: [info.name.toLowerCase(), tool, 'park', 'green', 'nature', 'recreation', 'entertainment'],
     });
@@ -149,6 +155,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'sports',
       keywords: [info.name.toLowerCase(), tool, 'sports', 'recreation', 'field'],
     });
@@ -165,6 +172,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'waterfront',
       keywords: [info.name.toLowerCase(), tool, 'water', 'waterfront', 'dock', 'pier', 'marina'],
     });
@@ -181,6 +189,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'community',
       keywords: [info.name.toLowerCase(), tool, 'community', 'building'],
     });
@@ -197,6 +206,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'utilities',
       keywords: [info.name.toLowerCase(), tool, 'utility', 'power', 'water', 'infrastructure', 'transit', 'station', 'train'],
     });
@@ -213,6 +223,7 @@ function buildMenuItems(): MenuItem[] {
       name: info.name,
       description: info.description,
       cost: info.cost,
+      shortcut: info.shortcut,
       category: 'special',
       keywords: [info.name.toLowerCase(), tool, 'special', 'landmark', 'attraction'],
     });
@@ -456,7 +467,10 @@ export function CommandMenu() {
                             )}
                           >
                             <div className="flex flex-col gap-0.5 min-w-0">
-                              <span className="font-medium truncate">{m(item.name as Parameters<typeof m>[0])}</span>
+                              <span className="font-medium truncate">
+                                {item.shortcut ? `(${item.shortcut}) ` : ''}
+                                {m(item.name as Parameters<typeof m>[0])}
+                              </span>
                               <span className={cn(
                                 'text-xs truncate',
                                 isSelected ? 'text-primary-foreground/70' : 'text-muted-foreground'

--- a/src/games/isocity/types/game.ts
+++ b/src/games/isocity/types/game.ts
@@ -30,23 +30,24 @@ export interface ToolInfo {
   cost: number;
   description: string;
   size?: number;
+  shortcut?: string;
 }
 
 export const TOOL_INFO: Record<Tool, ToolInfo> = {
-  select: { name: msg('Select'), cost: 0, description: msg('Click to view tile info') },
-  bulldoze: { name: msg('Bulldoze'), cost: 10, description: msg('Remove buildings and zones') },
-  road: { name: msg('Road'), cost: 25, description: msg('Connect your city') },
-  rail: { name: msg('Rail'), cost: 40, description: msg('Build railway tracks') },
-  subway: { name: msg('Subway'), cost: 50, description: msg('Underground transit') },
+  select: { name: msg('Select'), cost: 0, description: msg('Click to view tile info'), shortcut: 'v' },
+  bulldoze: { name: msg('Bulldoze'), cost: 10, description: msg('Remove buildings and zones'), shortcut: 'b' },
+  road: { name: msg('Road'), cost: 25, description: msg('Connect your city'), shortcut: 'r' },
+  rail: { name: msg('Rail'), cost: 40, description: msg('Build railway tracks'), shortcut: 'l' },
+  subway: { name: msg('Subway'), cost: 50, description: msg('Underground transit'), shortcut: 'u' },
   expand_city: { name: msg('Expand City'), cost: 0, description: msg('Add 15 tiles to each edge') },
   shrink_city: { name: msg('Shrink City'), cost: 0, description: msg('Remove 15 tiles from each edge') },
   tree: { name: msg('Tree'), cost: 15, description: msg('Plant trees to improve environment') },
-  zone_residential: { name: msg('Residential'), cost: 50, description: msg('Zone for housing') },
-  zone_commercial: { name: msg('Commercial'), cost: 50, description: msg('Zone for shops and offices') },
-  zone_industrial: { name: msg('Industrial'), cost: 50, description: msg('Zone for factories') },
-  zone_dezone: { name: msg('De-zone'), cost: 0, description: msg('Remove zoning') },
-  zone_water: { name: msg('Water Terraform'), cost: 50000, description: msg('Terraform land into water') },
-  zone_land: { name: msg('Land Terraform'), cost: 50000, description: msg('Terraform water into land') },
+  zone_residential: { name: msg('Residential'), cost: 50, description: msg('Zone for housing'), shortcut: '1' },
+  zone_commercial: { name: msg('Commercial'), cost: 50, description: msg('Zone for shops and offices'), shortcut: '2' },
+  zone_industrial: { name: msg('Industrial'), cost: 50, description: msg('Zone for factories'), shortcut: '3' },
+  zone_dezone: { name: msg('De-zone'), cost: 0, description: msg('Remove zoning'), shortcut: 'x' },
+  zone_water: { name: msg('Water Terraform'), cost: 50000, description: msg('Terraform land into water'), shortcut: 'o' },
+  zone_land: { name: msg('Land Terraform'), cost: 50000, description: msg('Terraform water into land'), shortcut: 'g' },
   police_station: { name: msg('Police'), cost: 500, description: msg('Increase safety'), size: 1 },
   fire_station: { name: msg('Fire Station'), cost: 500, description: msg('Fight fires'), size: 1 },
   hospital: { name: msg('Hospital'), cost: 1000, description: msg('Improve health (2x2)'), size: 2 },


### PR DESCRIPTION
This pull request adds keyboard shortcut support for game tools and improves the visibility of these shortcuts throughout the UI. Users can now quickly switch tools using their keyboard, and the assigned shortcuts are displayed in tooltips, sidebars, and command menus for better discoverability.


<img width="593" height="1000" alt="Screenshot 2026-01-29 at 1 04 35 AM" src="https://github.com/user-attachments/assets/0475c09c-8125-4e1f-9e2e-4f4142e7aa05" />



**Keyboard shortcut integration and tool switching:**
- Added a `shortcut` property to `ToolInfo` and assigned intuitive shortcut keys to major tools in `TOOL_INFO`, such as 'b' for bulldoze, 'r' for road, and number keys for zoning tools.
- Implemented global keyboard handling in `Game.tsx` to allow switching tools using the defined shortcuts, replacing the previous hardcoded key handling. [[1]](diffhunk://#diff-95541a94c4cee36ca1b557c64a3a7c81781356aad3d81ecd1ecf2afc6eb5f96eL5-R5) [[2]](diffhunk://#diff-95541a94c4cee36ca1b557c64a3a7c81781356aad3d81ecd1ecf2afc6eb5f96eR42-R50) [[3]](diffhunk://#diff-95541a94c4cee36ca1b557c64a3a7c81781356aad3d81ecd1ecf2afc6eb5f96eL174-R194)

**UI enhancements for shortcut visibility:**
- Updated the sidebar and hover submenu to display each tool's shortcut key next to its name, making shortcuts easily discoverable. [[1]](diffhunk://#diff-7a883290ce03b4b7d9f4e51e785c18f089ad84dfb02bb69d2e9c10f4e3e0bc1fL245-R245) [[2]](diffhunk://#diff-7a883290ce03b4b7d9f4e51e785c18f089ad84dfb02bb69d2e9c10f4e3e0bc1fL651-R651)
- Modified the command menu system to include and display shortcut keys for tools, zones, and other menu items. The `MenuItem` type and all relevant menu item builders now include the `shortcut` property, and the command menu UI shows the shortcut next to each item. [[1]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR31) [[2]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR65) [[3]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR82) [[4]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR107) [[5]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR124) [[6]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR141) [[7]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR158) [[8]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR175) [[9]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR192) [[10]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR209) [[11]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bR226) [[12]](diffhunk://#diff-4b26772288779848667af3ee2a80632f510fdc7305d3e8b7aae8ca7ec29e413bL459-R473)

**Minor improvements:**
- Fixed a missing dependency in a `useEffect` hook in `Game.tsx` for proper effect execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly UI/input plumbing around tool selection; primary risk is shortcut collisions or unintended tool switching in edge cases.
> 
> **Overview**
> Adds a `shortcut` field to `TOOL_INFO` and assigns default keys to core tools/zoning actions (e.g., `b`, `r`, `1`-`3`). `Game.tsx` now derives a key→tool map from `TOOL_INFO` and uses it in the global keydown handler (replacing the prior hardcoded bulldoze shortcut) to switch tools when no modifier keys are held.
> 
> Improves shortcut discoverability by rendering shortcuts alongside tool names in the sidebar flyouts and the command menu, and extends command menu items to carry/display the shortcut metadata. Also fixes a missing `useEffect` dependency (`gt`) in `Game.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c9da133fb2a3c4b72033c7369430878bfd115d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->