### PR TITLE
feat(coaster): add WASD/arrow key panning to match iso-city controls

### DIFF
--- a/src/components/coaster/CoasterGrid.tsx
+++ b/src/components/coaster/CoasterGrid.tsx
@@ -16,6 +16,7 @@ import { drawGuest } from '@/components/coaster/guests';
 import { useCoasterLightingSystem } from '@/components/coaster/lightingSystem';
 import { useCoasterCloudSystem, Cloud } from '@/components/coaster/cloudSystem';
 import { drawBeachOnWater } from '@/components/game/drawing';
+import { KEY_PAN_SPEED } from '@/components/game/types';
 
 // Track tools that support drag-to-draw
 const TRACK_DRAG_TOOLS: Tool[] = [
@@ -53,7 +54,6 @@ const TILE_HEIGHT = TILE_WIDTH * HEIGHT_RATIO;
 const ZOOM_MIN = 0.3;
 const ZOOM_MAX = 2.5;
 const HEIGHT_UNIT = 20;
-const KEY_PAN_SPEED = 520; // pixels per second (same as city game)
 
 // Water texture path (same as city game)
 const WATER_ASSET_PATH = '/assets/water.png';
@@ -2624,6 +2624,10 @@ export function CoasterGrid({
       pressed.delete(key);
     };
 
+    const handleBlur = () => {
+      pressed.clear();
+    };
+
     let animationFrameId = 0;
     let lastTime = performance.now();
 
@@ -2664,11 +2668,13 @@ export function CoasterGrid({
 
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
     animationFrameId = requestAnimationFrame(tick);
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleBlur);
       cancelAnimationFrame(animationFrameId);
       pressed.clear();
     };

--- a/src/components/game/CanvasIsometricGrid.tsx
+++ b/src/components/game/CanvasIsometricGrid.tsx
@@ -623,6 +623,10 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
       pressed.delete(key);
     };
 
+    const handleBlur = () => {
+      pressed.clear();
+    };
+
     let animationFrameId = 0;
     let lastTime = performance.now();
 
@@ -661,11 +665,13 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
 
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
     animationFrameId = requestAnimationFrame(tick);
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleBlur);
       cancelAnimationFrame(animationFrameId);
       pressed.clear();
     };


### PR DESCRIPTION
Harmonizes camera controls between iso-city and iso-coaster. 

Added keyboard-based panning with the same speed and bounds logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/input change limited to viewport movement; main risk is minor regressions in key handling or panning bounds/feel.
> 
> **Overview**
> Adds **keyboard-based camera panning** to `CoasterGrid` using WASD/arrow keys, matching the iso-city control feel/speed via shared `KEY_PAN_SPEED` and clamping movement to the same map bounds.
> 
> Also updates `CanvasIsometricGrid` to clear the pressed-key state on `window.blur`, preventing “stuck key” panning when the tab/window loses focus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b00fb562fa4d0bb2a5a11cf4cdb10976d5e6a4aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>b00fb56</u></sup><!-- /BUGBOT_STATUS -->