### PR TITLE
Coaster banked turns

### DIFF
--- a/src/games/coaster/types/game.ts
+++ b/src/games/coaster/types/game.ts
@@ -171,8 +171,8 @@ export const TOOL_INFO: Record<Tool, ToolInfo> = {
   
   coaster_build: { name: 'Coaster Build Mode', cost: 0, description: 'Start building a coaster', category: 'coasters' },
   coaster_track: { name: 'Track: Straight', cost: 20, description: 'Place straight track segments', category: 'coasters' },
-  coaster_turn_left: { name: 'Track: Left Turn', cost: 25, description: 'Place a left turn segment', category: 'coasters' },
-  coaster_turn_right: { name: 'Track: Right Turn', cost: 25, description: 'Place a right turn segment', category: 'coasters' },
+  coaster_turn_left: { name: 'Track: Banked Left Turn', cost: 25, description: 'Place a banked left turn segment', category: 'coasters' },
+  coaster_turn_right: { name: 'Track: Banked Right Turn', cost: 25, description: 'Place a banked right turn segment', category: 'coasters' },
   coaster_slope_up: { name: 'Track: Slope Up', cost: 30, description: 'Place a rising track segment', category: 'coasters' },
   coaster_slope_down: { name: 'Track: Slope Down', cost: 30, description: 'Place a descending track segment', category: 'coasters' },
   coaster_loop: { name: 'Track: Loop', cost: 150, description: 'Place a vertical loop element', category: 'coasters' },

--- a/src/games/coaster/types/tracks.ts
+++ b/src/games/coaster/types/tracks.ts
@@ -83,6 +83,9 @@ export type TrackPieceType =
 /** Bank angle for turns */
 export type BankAngle = 0 | 15 | 30 | 45 | 60 | 90;
 
+/** Default bank angle for turn pieces */
+export const DEFAULT_BANK_ANGLE: BankAngle = 30;
+
 /** Strut/support material style */
 export type StrutStyle = 'wood' | 'metal';
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ba891391-67d3-47c2-bacd-cfecfd74c2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba891391-67d3-47c2-bacd-cfecfd74c2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core coaster track placement and rendering logic; mistakes could create broken track connectivity or visual glitches, but scope is limited to turn handling.
> 
> **Overview**
> **Adds banked coaster turn support** by introducing new `turn_banked_*` track piece types and a shared `DEFAULT_BANK_ANGLE`.
> 
> Track building now selects banked vs flat turn pieces based on the coaster type’s banking capability, persists `bankAngle` on placed pieces (including auto-generated turns), and updates direction/connection logic to treat all turn variants consistently. Rendering updates `drawCurvedTrack` to accept a `bankAngle` and visually bank curved rails/ties; the UI tool labels are updated to “Banked Left/Right Turn.”
> 
> *Review note:* `drawCurvedTrack(ctx, startX, startY, startDir, turnRight, height, trackColor, strutStyle, bankAngle, ...)` has multiple same-typed positional args (several `number`s/`string`s), making call sites prone to accidental reordering—consider switching to a single options object with named fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97dd2612bafd1460bcbc88065360823e5d57200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 2 potential issues for commit <u>a97dd26</u></sup><!-- /BUGBOT_STATUS -->