### PR TITLE
Iso coaster city button

### DIFF
--- a/src/app/coaster/page.tsx
+++ b/src/app/coaster/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { CoasterProvider } from '@/context/CoasterContext';
 import { MultiplayerContextProvider, useMultiplayerOptional } from '@/context/MultiplayerContext';
@@ -269,6 +270,7 @@ function SavedParkCard({ park, onLoad, onDelete }: { park: SavedParkMeta; onLoad
 
 function CoasterPageContent() {
   const multiplayer = useMultiplayerOptional();
+  const router = useRouter();
   const [showGame, setShowGame] = useState(false);
   const [startFresh, setStartFresh] = useState(false);
   const [hasSaved, setHasSaved] = useState(false);
@@ -309,6 +311,15 @@ function CoasterPageContent() {
     refreshSavedParks();
     window.history.replaceState({}, '', '/coaster');
   };
+
+  const handleBackToIsoCity = useCallback(() => {
+    multiplayer?.leaveRoom();
+    setShowGame(false);
+    setStartFresh(false);
+    setLoadParkId(null);
+    setPendingRoomCode(null);
+    router.push('/');
+  }, [multiplayer, router, setShowGame, setStartFresh, setLoadParkId, setPendingRoomCode]);
 
   const handleDeletePark = (park: SavedParkMeta) => {
     const autosaveState = loadCoasterStateFromStorage(COASTER_AUTOSAVE_KEY);
@@ -421,12 +432,13 @@ function CoasterPageContent() {
                   Load Example
                 </Button>
 
-                <a
-                  href="/"
+                <button
+                  type="button"
+                  onClick={handleBackToIsoCity}
                   className="w-full text-center py-2 text-sm font-light tracking-wide text-white/40 hover:text-white/70 transition-colors duration-200"
                 >
                   Back to IsoCity
-                </a>
+                </button>
                 <a
                   href="https://github.com/amilich/isometric-city"
                   target="_blank"


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-527247c7-b66d-4b9b-8c3b-c78c2c41fb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-527247c7-b66d-4b9b-8c3b-c78c2c41fb0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only navigation change; minimal risk beyond potential routing/regression in back-navigation behavior.
> 
> **Overview**
> Updates the coaster landing page’s “Back to IsoCity” control to use Next.js client-side navigation (`useRouter().push('/')`) instead of a plain link, and ensures any multiplayer room is left and local coaster UI state is reset before navigating away.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0da11717a6f08f942220515c5a58ca24f6b1682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>a0da117</u></sup><!-- /BUGBOT_STATUS -->