### PR TITLE
Fix false power/water warnings for non-building tiles

### DIFF
--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -1985,8 +1985,10 @@ function generateAdvisorMessages(stats: Stats, services: ServiceCoverage, grid: 
   
   for (const row of grid) {
     for (const tile of row) {
-      // Only count zoned buildings (not grass)
-      if (tile.zone !== 'none' && tile.building.type !== 'grass') {
+      // Only count actual zoned buildings (exclude terrain, infrastructure, and placeholders)
+      const btype = tile.building.type;
+      if (tile.zone !== 'none' && btype !== 'grass' && btype !== 'water' &&
+          btype !== 'road' && btype !== 'bridge' && btype !== 'empty') {
         if (!tile.building.powered) unpoweredBuildings++;
         if (!tile.building.watered) unwateredBuildings++;
       }


### PR DESCRIPTION
Improved the advisor message filtering to exclude terrain and infrastructure tiles (water, road, bridge, empty) when counting unpowered and unwatered buildings. This prevents false warnings about missing power or water for tiles that don't represent actual buildings.

Changes made:
- Extended the building type filter to exclude water, road, bridge, and empty tiles
- Improved comments to clarify what tiles are being excluded
- Minor optimization by caching the building type in a variable

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to advisor message counting logic only; low risk aside from potentially changing when utility warnings appear.
> 
> **Overview**
> Fixes false Power/Water advisor warnings by tightening the `generateAdvisorMessages` counters to only include *actual zoned buildings* and exclude non-building tile types (`water`, `road`, `bridge`, `empty`, in addition to `grass`).
> 
> Also does a tiny micro-optimization by caching `tile.building.type` into `btype` while scanning the grid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91e4d0a48dbcbb6d157572616f4cc88db295809a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>91e4d0a</u></sup><!-- /BUGBOT_STATUS -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amilich/isometric-city/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
