### PR TITLE
Feature Request: Viewing radius of buildings such as powerplants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Stage 1: Install dependencies
+FROM node:20-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Stage 2: Rebuild the source code only when needed
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# Stage 3: Production image, copy all the files and run next
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+    restart: always

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const { withGTConfig } = require("gt-next/config");
 const nextConfig = {
   reactStrictMode: true,
   reactCompiler: true,
+  output: 'standalone',
 };
 
 module.exports = withGTConfig(nextConfig);

--- a/src/components/game/CanvasIsometricGrid.tsx
+++ b/src/components/game/CanvasIsometricGrid.tsx
@@ -58,6 +58,7 @@ import {
   OVERLAY_CIRCLE_COLORS,
   OVERLAY_CIRCLE_FILL_COLORS,
   OVERLAY_HIGHLIGHT_COLORS,
+  getOverlayForTool,
 } from '@/components/game/overlays';
 import { SERVICE_CONFIG, SERVICE_RANGE_INCREASE_PER_LEVEL } from '@/lib/simulation';
 import { drawPlaceholderBuilding } from '@/components/game/placeholders';
@@ -125,7 +126,7 @@ export interface CanvasIsometricGridProps {
 
 // Canvas-based Isometric Grid - HIGH PERFORMANCE
 export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile, isMobile = false, navigationTarget, onNavigationComplete, onViewportChange, onBargeDelivery }: CanvasIsometricGridProps) {
-  const { state, latestStateRef, placeAtTile, finishTrackDrag, connectToCity, checkAndDiscoverCities, currentSpritePack, visualHour } = useGame();
+  const { state, latestStateRef, placeAtTile, finishTrackDrag, connectToCity, checkAndDiscoverCities, currentSpritePack, visualHour, showRangePreview } = useGame();
   const { grid, gridSize, selectedTool, speed, adjacentCities, waterBodies, gameVersion } = state;
   
   // PERF: Use latestStateRef for real-time grid access in animation loops
@@ -2222,6 +2223,41 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
         const buildingType = selectedTool as BuildingType;
         const buildingSize = getBuildingSize(buildingType);
         
+        // Draw service range preview if the building has a service range
+        if (buildingType in SERVICE_CONFIG && showRangePreview) {
+          const config = SERVICE_CONFIG[buildingType as keyof typeof SERVICE_CONFIG];
+          const range = config.range;
+          
+          // Calculate center of the range circle based on the footprint anchor (top-left)
+          const { screenX: anchorScreenX, screenY: anchorScreenY } = gridToScreen(hoveredTile.x, hoveredTile.y, 0, 0);
+          
+          // Anchor tile center
+          const centerX = anchorScreenX + TILE_WIDTH / 2;
+          const centerY = anchorScreenY + TILE_HEIGHT / 2;
+          
+          // Isometric ellipse radii (in pixels)
+          const radiusX = range * (TILE_WIDTH / 2);
+          const radiusY = range * (TILE_HEIGHT / 2);
+          
+          // Map building type to overlay mode colors
+          const toolOverlayMode = getOverlayForTool(selectedTool);
+          const strokeColor = OVERLAY_CIRCLE_COLORS[toolOverlayMode] || 'rgba(255, 255, 255, 0.8)';
+          const fillColor = OVERLAY_CIRCLE_FILL_COLORS[toolOverlayMode] || 'rgba(255, 255, 255, 0.12)';
+          
+          // Draw isometric ellipse
+          ctx.save();
+          ctx.strokeStyle = strokeColor;
+          ctx.lineWidth = 2 / zoom; // Keep consistent stroke width across zooms
+          ctx.setLineDash([6 / zoom, 4 / zoom]); // Dash pattern that scales with zoom
+          ctx.beginPath();
+          ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, Math.PI * 2);
+          ctx.stroke();
+          
+          ctx.fillStyle = fillColor;
+          ctx.fill();
+          ctx.restore();
+        }
+        
         // Draw highlight for each tile in the building footprint
         for (let dx = 0; dx < buildingSize.width; dx++) {
           for (let dy = 0; dy < buildingSize.height; dy++) {
@@ -2375,7 +2411,7 @@ export function CanvasIsometricGrid({ overlayMode, selectedTile, setSelectedTile
     }
     
     ctx.setTransform(1, 0, 0, 1, 0, 0);
-  }, [hoveredTile, selectedTile, selectedTool, offset, zoom, gridSize, grid, isDragging, dragStartTile, dragEndTile]);
+  }, [hoveredTile, selectedTile, selectedTool, offset, zoom, gridSize, grid, isDragging, dragStartTile, dragEndTile, showRangePreview]);
   
   // Animate decorative car traffic AND emergency vehicles on top of the base canvas
   useEffect(() => {

--- a/src/components/game/OverlayModeToggle.tsx
+++ b/src/components/game/OverlayModeToggle.tsx
@@ -14,6 +14,7 @@ import {
   HealthIcon,
   EducationIcon,
   SubwayIcon,
+  EnvironmentIcon,
 } from '@/components/ui/Icons';
 import { OverlayMode } from './types';
 import { OVERLAY_CONFIG, getOverlayButtonClass } from './overlays';
@@ -41,6 +42,7 @@ const OVERLAY_ICONS: Record<OverlayMode, React.ReactNode> = {
   health: <HealthIcon size={14} />,
   education: <EducationIcon size={14} />,
   subway: <SubwayIcon size={14} />,
+  pollution: <EnvironmentIcon size={14} />,
 };
 
 // ============================================================================

--- a/src/components/game/overlays.ts
+++ b/src/components/game/overlays.ts
@@ -84,6 +84,12 @@ export const OVERLAY_CONFIG: Record<OverlayMode, OverlayConfig> = {
     activeColor: 'bg-yellow-500',
     hoverColor: 'hover:bg-yellow-600',
   },
+  pollution: {
+    label: 'Pollution',
+    title: 'Pollution Map',
+    activeColor: 'bg-stone-500',
+    hoverColor: 'hover:bg-stone-600',
+  },
 };
 
 /** Map of building tools to their corresponding overlay mode */
@@ -184,6 +190,12 @@ export function getOverlayFillStyle(
         ? 'rgba(245, 158, 11, 0.7)'  // Bright amber for existing subway
         : 'rgba(40, 30, 20, 0.4)';   // Dark brown tint for "underground" view
 
+    case 'pollution':
+      if (tile.pollution <= 0.1) return NO_OVERLAY;
+      // Smog opacity scales with pollution intensity (brown-grey color)
+      const alpha = Math.min(0.65, Math.max(0.15, tile.pollution / 60));
+      return `rgba(139, 115, 85, ${alpha})`;
+
     case 'none':
     default:
       return NO_OVERLAY;
@@ -200,7 +212,7 @@ export function getOverlayForTool(tool: string): OverlayMode {
 
 /** List of all overlay modes (for iteration) */
 export const OVERLAY_MODES: OverlayMode[] = [
-  'none', 'power', 'water', 'fire', 'police', 'health', 'education', 'subway'
+  'none', 'power', 'water', 'fire', 'police', 'health', 'education', 'subway', 'pollution'
 ];
 
 // ============================================================================
@@ -217,6 +229,7 @@ export const OVERLAY_TO_BUILDING_TYPES: Record<OverlayMode, string[]> = {
   health: ['hospital'],
   education: ['school', 'university'],
   subway: ['subway_station'],
+  pollution: ['power_plant', 'factory_small', 'factory_medium', 'factory_large', 'warehouse'],
 };
 
 /** Overlay circle stroke colors (light/visible colors) */
@@ -229,6 +242,7 @@ export const OVERLAY_CIRCLE_COLORS: Record<OverlayMode, string> = {
   health: 'rgba(134, 239, 172, 0.8)',  // Light green
   education: 'rgba(196, 181, 253, 0.8)', // Light purple
   subway: 'rgba(253, 224, 71, 0.8)',   // Yellow
+  pollution: 'transparent',
 };
 
 /** Building highlight glow colors */
@@ -241,6 +255,7 @@ export const OVERLAY_HIGHLIGHT_COLORS: Record<OverlayMode, string> = {
   health: 'rgba(34, 197, 94, 1)',      // Green
   education: 'rgba(168, 85, 247, 1)',  // Purple
   subway: 'rgba(234, 179, 8, 1)',      // Yellow
+  pollution: 'rgba(239, 68, 68, 0.8)',  // Red glow outlines for pollution sources
 };
 
 /** Overlay circle fill colors (subtle, for area visibility) */
@@ -253,4 +268,5 @@ export const OVERLAY_CIRCLE_FILL_COLORS: Record<OverlayMode, string> = {
   health: 'rgba(134, 239, 172, 0.12)',
   education: 'rgba(196, 181, 253, 0.12)',
   subway: 'rgba(253, 224, 71, 0.12)',
+  pollution: 'transparent',
 };

--- a/src/components/game/panels/SettingsPanel.tsx
+++ b/src/components/game/panels/SettingsPanel.tsx
@@ -128,7 +128,7 @@ function formatMoney(money: number): string {
 }
 
 export function SettingsPanel() {
-  const { state, setActivePanel, setDisastersEnabled, newGame, loadState, exportState, expandCity, shrinkCity, currentSpritePack, availableSpritePacks, setSpritePack, dayNightMode, setDayNightMode, getSavedCityInfo, restoreSavedCity, clearSavedCity, savedCities, saveCity, loadSavedCity, deleteSavedCity, renameSavedCity } = useGame();
+  const { state, setActivePanel, setDisastersEnabled, newGame, loadState, exportState, expandCity, shrinkCity, currentSpritePack, availableSpritePacks, setSpritePack, dayNightMode, setDayNightMode, getSavedCityInfo, restoreSavedCity, clearSavedCity, savedCities, saveCity, loadSavedCity, deleteSavedCity, renameSavedCity, showRangePreview, setShowRangePreview } = useGame();
   const { disastersEnabled, cityName, gridSize, id: currentCityId } = state;
   const m = useMessages();
   const searchParams = useSearchParams();
@@ -230,6 +230,17 @@ export function SettingsPanel() {
               <Switch
                 checked={disastersEnabled}
                 onCheckedChange={setDisastersEnabled}
+              />
+            </div>
+            
+            <div className="flex items-center justify-between py-2 gap-4">
+              <div className="flex-1 min-w-0">
+                <Label>{m(msg('Show Range Previews'))}</Label>
+                <p className="text-muted-foreground text-xs">{m(msg('Show building ranges when placing them'))}</p>
+              </div>
+              <Switch
+                checked={showRangePreview}
+                onCheckedChange={setShowRangePreview}
               />
             </div>
             

--- a/src/components/game/types.ts
+++ b/src/components/game/types.ts
@@ -527,7 +527,7 @@ export type WorldRenderState = {
 };
 
 // Overlay modes for visualization
-export type OverlayMode = 'none' | 'power' | 'water' | 'fire' | 'police' | 'health' | 'education' | 'subway';
+export type OverlayMode = 'none' | 'power' | 'water' | 'fire' | 'police' | 'health' | 'education' | 'subway' | 'pollution';
 
 // ============================================================================
 // Train Types

--- a/src/components/mobile/MobileToolbar.tsx
+++ b/src/components/mobile/MobileToolbar.tsx
@@ -220,6 +220,7 @@ const UI_LABELS = {
   health: msg('Health'),
   education: msg('Education'),
   subway: msg('Subway'),
+  pollution: msg('Pollution'),
   budget: msg('Budget'),
   statistics: msg('Statistics'),
   advisors: msg('Advisors'),
@@ -239,7 +240,7 @@ const toolCategories = {
   'SPECIAL': ['stadium', 'museum', 'airport', 'space_program', 'city_hall', 'amusement_park'] as Tool[],
 };
 
-type OverlayMode = 'none' | 'power' | 'water' | 'fire' | 'police' | 'health' | 'education' | 'subway';
+type OverlayMode = 'none' | 'power' | 'water' | 'fire' | 'police' | 'health' | 'education' | 'subway' | 'pollution';
 
 interface MobileToolbarProps {
   onOpenPanel: (panel: 'budget' | 'statistics' | 'advisors' | 'settings') => void;
@@ -500,6 +501,14 @@ export function MobileToolbar({ onOpenPanel, overlayMode = 'none', setOverlayMod
                     onClick={() => setOverlayMode('subway')}
                   >
                     {m(UI_LABELS.subway)}
+                  </Button>
+                  <Button
+                    variant={overlayMode === 'pollution' ? 'default' : 'ghost'}
+                    size="sm"
+                    className={`h-10 w-full text-xs ${overlayMode === 'pollution' ? 'bg-stone-500 hover:bg-stone-600' : ''}`}
+                    onClick={() => setOverlayMode('pollution')}
+                  >
+                    {m(UI_LABELS.pollution)}
                   </Button>
                 </div>
               </div>

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -91,6 +91,9 @@ type GameContextValue = {
   // Day/night mode override
   dayNightMode: DayNightMode;
   setDayNightMode: (mode: DayNightMode) => void;
+  // Range preview setting
+  showRangePreview: boolean;
+  setShowRangePreview: (enabled: boolean) => void;
   visualHour: number; // The hour to use for rendering (respects day/night mode override)
   // Save/restore city for shared links
   saveCurrentCityForRestore: () => void;
@@ -669,6 +672,9 @@ export function GameProvider({ children, startFresh = false }: { children: React
   // Saved cities state for multi-city save system
   const [savedCities, setSavedCities] = useState<SavedCityMeta[]>([]);
   
+  // Range preview state
+  const [showRangePreview, setShowRangePreviewState] = useState<boolean>(true);
+  
   // Load game state and sprite pack from localStorage on mount (client-side only)
   useEffect(() => {
     // Load sprite pack preference
@@ -680,6 +686,12 @@ export function GameProvider({ children, startFresh = false }: { children: React
     // Load day/night mode preference
     const savedDayNightMode = loadDayNightMode();
     setDayNightModeState(savedDayNightMode);
+    
+    // Load show range preview preference
+    const savedShowRange = localStorage.getItem('isocity-show-range-preview');
+    if (savedShowRange !== null) {
+      setShowRangePreviewState(savedShowRange === 'true');
+    }
     
     // Load saved cities index
     const cities = loadSavedCitiesIndex();
@@ -1115,6 +1127,11 @@ export function GameProvider({ children, startFresh = false }: { children: React
   const setDayNightMode = useCallback((mode: DayNightMode) => {
     setDayNightModeState(mode);
     saveDayNightMode(mode);
+  }, []);
+
+  const setShowRangePreview = useCallback((enabled: boolean) => {
+    setShowRangePreviewState(enabled);
+    localStorage.setItem('isocity-show-range-preview', String(enabled));
   }, []);
 
   // Compute the visual hour based on the day/night mode override
@@ -1664,6 +1681,9 @@ export function GameProvider({ children, startFresh = false }: { children: React
     dayNightMode,
     setDayNightMode,
     visualHour,
+    // Range preview setting
+    showRangePreview,
+    setShowRangePreview,
     // Save/restore city for shared links
     saveCurrentCityForRestore,
     restoreSavedCity,


### PR DESCRIPTION
This is a feature request that adds the ability to view the affected area when placing down buildings such as power plants, fire stations, police stations, etc as well as adds a dockerfile with a compose for easy deployment on local servers. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows service range when placing service buildings and adds a Pollution overlay to help plan placements. Also adds Docker support for easy local deployment with a standalone Next.js build.

- New Features
  - Service range previews during placement for buildings with ranges (e.g., power, fire, police). Draws an isometric ellipse scaled with zoom and colored by the matching overlay. Toggle in Settings > “Show Range Previews” (persisted).
  - Pollution overlay on desktop and mobile, with icon and color shading that scales with tile pollution.

- Migration
  - To run locally with Docker: docker compose up --build
  - App serves on http://localhost:3000 (Next.js output set to standalone).

<sup>Written for commit ffab27404fe514f1345b4fa1e9d9a251e753f1d1. Summary will update on new commits. <a href="https://cubic.dev/pr/amilich/isometric-city/pull/446?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

