### PR TITLE
docs: link Next.js in README tagline (test PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IsoCity & IsoCoaster
 
-Open-source isometric simulation game built with NextJS, TypeScript, and HTML5 Canvas.
+Open-source isometric simulation game built with [Next.js](https://nextjs.org/), TypeScript, and HTML5 Canvas.
 
 <table>
 <tr>


### PR DESCRIPTION
## Summary
Tiny test PR: normalize the README opening line to **Next.js** (matching the Tech Stack section) and add a link to the Next.js site.

## Change
- `README.md`: `NextJS` → linked `Next.js`

No code changes — local WIP on other files is intentionally **not** included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the README tagline to `Next.js` and add a link to https://nextjs.org/ to match the Tech Stack and help readers find the framework.

<sup>Written for commit e36ea2faa204c200137313b4a1ac441d624ec2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

