### PR TITLE
docs: link Next.js in README intro (test PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IsoCity & IsoCoaster
 
-Open-source isometric city and theme park builder built with NextJS, TypeScript, and HTML5 Canvas.
+Open-source isometric city and theme park builder built with [Next.js](https://nextjs.org/), TypeScript, and HTML5 Canvas.
 
 <table>
 <tr>


### PR DESCRIPTION
Small README tweak for PR workflow testing.

- Normalize Next.js spelling and add link in the tagline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README intro to use the correct `Next.js` name and link to https://nextjs.org/ in the project tagline. Improves clarity and branding for readers.

<sup>Written for commit 1a5d1fc89366c0b95324ce97d43619de84bf4839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

