### PR TITLE
docs: polish README and AGENTS dev routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - `npm run build` - Production build (also type-checks)
 - `npm run lint` - Run ESLint
 - No test framework configured
+- Dev server: `http://localhost:3000` (IsoCity), `/coaster` for IsoCoaster
 
 ## Architecture
 Next.js 16 + React 19 isometric city-builder game with canvas rendering.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Made with [Cursor](https://cursor.com).
     -   **Economy & Resources**: Resource management, zoning (Residential, Commercial, Industrial), and city growth logic.
 -   **Interactive Grid**: Tile-based placement system for buildings, roads, rail, parks, utilities, and more.
 -   **State Management**: Save and load functionality for multiple cities.
--   **Responsive Design**: Mobile-friendly interface with touch friendly controls, drawers, and toolbars.
+-   **Responsive Design**: Mobile-friendly interface with touch-friendly controls, drawers, and toolbars.
 
 ## Tech Stack
 
--   **Framework**: [Next.js 16](https://nextjs.org/)
+-   **Framework**: [Next.js 16](https://nextjs.org/) with [React 19](https://react.dev/)
 -   **Language**: [TypeScript](https://www.typescriptlang.org/)
 -   **Graphics**: HTML5 Canvas (No external game engine libraries; pure native implementation).
 -   **Icons**: Lucide React.


### PR DESCRIPTION
## Summary
Small documentation polish for local dev and tech stack clarity.

## Changes
- README: hyphenate `touch-friendly`, link React 19 in Tech Stack
- AGENTS.md: note default dev URLs for IsoCity and IsoCoaster

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished docs for local dev and tech stack clarity. README hyphenates "touch-friendly" and adds `react@19` with `next@16`; AGENTS lists default dev URLs for IsoCity and IsoCoaster.

<sup>Written for commit 2ecf16c69d8a513e2c7d8442e203690e04c8f31e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

