### PR TITLE
Test PR: README NextJS spelling tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IsoCity & IsoCoaster
 
-Open-source isometric city and theme park builder built with NextJS, TypeScript, and HTML5 Canvas.
+Open-source isometric city and theme park builder built with Next.js, TypeScript, and HTML5 Canvas.
 
 <table>
 <tr>


### PR DESCRIPTION
Small test PR. Updates 'NextJS' to 'Next.js' in the README intro line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the README intro to use the proper `Next.js` spelling for accuracy and consistency.

<sup>Written for commit 9233487d3485cbec9790ca9ea5a42219e6a70744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

