### PR TITLE
docs: tidy Next.js spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IsoCity & IsoCoaster
 
-Open-source isometric city and theme park builder built with NextJS, TypeScript, and HTML5 Canvas.
+Open-source isometric city and theme park builder built with Next.js, TypeScript, and HTML5 Canvas.
 
 <table>
 <tr>


### PR DESCRIPTION
Small test PR: normalizes "NextJS" to "Next.js" in the README intro line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes "NextJS" to `Next.js` in the README intro for correct branding and consistency.

<sup>Written for commit 11616b765bf629f7af947a444e9b4ef8e4811eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

