### PR TITLE
perf: speed up road BFS, Set lookups, and vehicle draw loops

### DIFF
--- a/src/components/game/gridFinders.ts
+++ b/src/components/game/gridFinders.ts
@@ -39,32 +39,32 @@ const PARK_TYPES = new Set<BuildingType>([
   'community_garden', 'pond_park', 'park_gate', 'mountain_lodge', 'mountain_trailhead'
 ]);
 
-// Sports facilities where pedestrians play sports
-export const SPORTS_TYPES: BuildingType[] = [
+// PERF: Sets for O(1) lookup; array exports kept for iteration compatibility
+export const SPORTS_TYPES_SET = new Set<BuildingType>([
   'basketball_courts', 'tennis', 'soccer_field_small', 'baseball_field_small',
   'football_field', 'baseball_stadium', 'stadium', 'swimming_pool', 'skate_park'
-];
+]);
+export const SPORTS_TYPES: BuildingType[] = [...SPORTS_TYPES_SET];
 
-// Recreation areas where pedestrians relax
-export const RELAXATION_TYPES: BuildingType[] = [
+export const RELAXATION_TYPES_SET = new Set<BuildingType>([
   'park', 'park_large', 'community_garden', 'pond_park', 'greenhouse_garden',
   'amphitheater', 'campground', 'marina_docks_small', 'pier_large'
-];
+]);
+export const RELAXATION_TYPES: BuildingType[] = [...RELAXATION_TYPES_SET];
 
-// Active recreation (not sitting)
-export const ACTIVE_RECREATION_TYPES: BuildingType[] = [
+export const ACTIVE_RECREATION_TYPES_SET = new Set<BuildingType>([
   'playground_small', 'playground_large', 'mini_golf_course', 'go_kart_track',
   'roller_coaster_small', 'amusement_park', 'mountain_trailhead'
-];
+]);
+export const ACTIVE_RECREATION_TYPES: BuildingType[] = [...ACTIVE_RECREATION_TYPES_SET];
 
-// Enterable buildings (pedestrians go inside)
-const ENTERABLE_BUILDING_TYPES: BuildingType[] = [
+const ENTERABLE_BUILDING_TYPES = new Set<BuildingType>([
   'shop_small', 'shop_medium', 'office_low', 'office_high', 'mall',
   'school', 'university', 'hospital', 'museum', 'community_center',
   'factory_small', 'factory_medium', 'factory_large', 'warehouse',
   'police_station', 'fire_station', 'city_hall', 'rail_station',
   'subway_station', 'mountain_lodge'
-];
+]);
 
 // Recreation area types for more specific destination finding
 export type RecreationType = 'sports' | 'relaxation' | 'active' | 'general';
@@ -156,11 +156,11 @@ export function findRecreationAreas(
     for (let x = 0; x < gridSize; x++) {
       const buildingType = grid[y][x].building.type;
       
-      if (SPORTS_TYPES.includes(buildingType)) {
+      if (SPORTS_TYPES_SET.has(buildingType)) {
         destinations.push({ x, y, type: 'sports', buildingType });
-      } else if (RELAXATION_TYPES.includes(buildingType)) {
+      } else if (RELAXATION_TYPES_SET.has(buildingType)) {
         destinations.push({ x, y, type: 'relaxation', buildingType });
-      } else if (ACTIVE_RECREATION_TYPES.includes(buildingType)) {
+      } else if (ACTIVE_RECREATION_TYPES_SET.has(buildingType)) {
         destinations.push({ x, y, type: 'active', buildingType });
       } else if (PARK_TYPES.has(buildingType)) {
         destinations.push({ x, y, type: 'general', buildingType });
@@ -187,7 +187,7 @@ export function findEnterableBuildings(
       
       // Only include active buildings (powered, not abandoned, construction complete)
       if (
-        ENTERABLE_BUILDING_TYPES.includes(buildingType) &&
+        ENTERABLE_BUILDING_TYPES.has(buildingType) &&
         tile.building.constructionProgress >= 100 &&
         !tile.building.abandoned
       ) {
@@ -202,21 +202,21 @@ export function findEnterableBuildings(
  * Check if a building type is a sports facility
  */
 export function isSportsFacility(buildingType: BuildingType): boolean {
-  return SPORTS_TYPES.includes(buildingType);
+  return SPORTS_TYPES_SET.has(buildingType);
 }
 
 /**
  * Check if a building type is a relaxation area
  */
 export function isRelaxationArea(buildingType: BuildingType): boolean {
-  return RELAXATION_TYPES.includes(buildingType);
+  return RELAXATION_TYPES_SET.has(buildingType);
 }
 
 /**
  * Check if a building type is enterable
  */
 export function isEnterableBuilding(buildingType: BuildingType): boolean {
-  return ENTERABLE_BUILDING_TYPES.includes(buildingType);
+  return ENTERABLE_BUILDING_TYPES.has(buildingType);
 }
 
 /**

--- a/src/components/game/utils.ts
+++ b/src/components/game/utils.ts
@@ -7,9 +7,13 @@ import { OPPOSITE_DIRECTION } from './constants';
 const MAX_PATH_LENGTH = 2048;
 const BFS_QUEUE_X = new Int16Array(MAX_PATH_LENGTH);
 const BFS_QUEUE_Y = new Int16Array(MAX_PATH_LENGTH);
-const BFS_PARENT_X = new Int16Array(MAX_PATH_LENGTH); // Parent index for path reconstruction
-const BFS_PARENT_Y = new Int16Array(MAX_PATH_LENGTH);
-const BFS_VISITED = new Uint8Array(256 * 256); // Max 256x256 grid size
+// Store parent queue index (not coordinates) so path reconstruction is O(path length)
+const BFS_PARENT_IDX = new Int16Array(MAX_PATH_LENGTH);
+// Generation stamp avoids clearing the whole visited array on every pathfind
+const BFS_VISITED = new Uint32Array(256 * 256); // Max 256x256 grid size
+let bfsVisitGeneration = 1;
+const BFS_DX = [-1, 1, 0, 0];
+const BFS_DY = [0, 0, -1, 1];
 
 // Get opposite direction
 export function getOppositeDirection(direction: CarDirection): CarDirection {
@@ -250,7 +254,6 @@ export function findPathOnRoads(
     return [{ x: startRoad.x, y: startRoad.y }];
   }
   
-  // PERF: Clear visited array only for the area we need (faster than full clear)
   // Using numeric keys: index = y * gridSize + x
   const maxIdx = gridSizeValue * gridSizeValue;
   if (maxIdx > BFS_VISITED.length) {
@@ -258,23 +261,21 @@ export function findPathOnRoads(
     return findPathOnRoadsLegacy(gridData, gridSizeValue, startRoad, targetRoad);
   }
   
-  // Clear visited (only the portion we'll use)
-  for (let i = 0; i < maxIdx; i++) {
-    BFS_VISITED[i] = 0;
+  // PERF: Stamp visited cells with a generation id instead of zeroing the array
+  bfsVisitGeneration++;
+  if (bfsVisitGeneration === 0) {
+    BFS_VISITED.fill(0);
+    bfsVisitGeneration = 1;
   }
+  const visitGen = bfsVisitGeneration;
   
   // BFS using pre-allocated arrays
   let queueHead = 0;
   let queueTail = 1;
   BFS_QUEUE_X[0] = startRoad.x;
   BFS_QUEUE_Y[0] = startRoad.y;
-  BFS_PARENT_X[0] = -1; // -1 indicates start node
-  BFS_PARENT_Y[0] = -1;
-  BFS_VISITED[startRoad.y * gridSizeValue + startRoad.x] = 1;
-  
-  // Direction offsets
-  const DX = [-1, 1, 0, 0];
-  const DY = [0, 0, -1, 1];
+  BFS_PARENT_IDX[0] = -1; // -1 indicates start node
+  BFS_VISITED[startRoad.y * gridSizeValue + startRoad.x] = visitGen;
   
   let foundIdx = -1;
   
@@ -291,49 +292,32 @@ export function findPathOnRoads(
     }
     
     for (let d = 0; d < 4; d++) {
-      const nx = cx + DX[d];
-      const ny = cy + DY[d];
+      const nx = cx + BFS_DX[d];
+      const ny = cy + BFS_DY[d];
       
       if (nx < 0 || ny < 0 || nx >= gridSizeValue || ny >= gridSizeValue) continue;
       
       const visitedIdx = ny * gridSizeValue + nx;
-      if (BFS_VISITED[visitedIdx]) continue;
+      if (BFS_VISITED[visitedIdx] === visitGen) continue;
       if (!isRoadTile(gridData, gridSizeValue, nx, ny)) continue;
       
-      BFS_VISITED[visitedIdx] = 1;
+      BFS_VISITED[visitedIdx] = visitGen;
       BFS_QUEUE_X[queueTail] = nx;
       BFS_QUEUE_Y[queueTail] = ny;
-      BFS_PARENT_X[queueTail] = cx;
-      BFS_PARENT_Y[queueTail] = cy;
+      BFS_PARENT_IDX[queueTail] = currentIdx;
       queueTail++;
     }
   }
   
   if (foundIdx === -1) return null;
   
-  // Reconstruct path by walking back through parents
+  // Reconstruct path by walking back through parent indices — O(path length)
   const pathReverse: { x: number; y: number }[] = [];
   let idx = foundIdx;
   
-  // Walk back through the BFS tree to reconstruct path
   while (idx >= 0) {
     pathReverse.push({ x: BFS_QUEUE_X[idx], y: BFS_QUEUE_Y[idx] });
-    
-    // Find parent index by searching queue
-    const px = BFS_PARENT_X[idx];
-    const py = BFS_PARENT_Y[idx];
-    
-    if (px === -1) break; // Reached start
-    
-    // Search backwards for parent position in queue
-    let parentIdx = -1;
-    for (let i = idx - 1; i >= 0; i--) {
-      if (BFS_QUEUE_X[i] === px && BFS_QUEUE_Y[i] === py) {
-        parentIdx = i;
-        break;
-      }
-    }
-    idx = parentIdx;
+    idx = BFS_PARENT_IDX[idx];
   }
   
   // Reverse to get path from start to target

--- a/src/components/game/vehicleSystems.ts
+++ b/src/components/game/vehicleSystems.ts
@@ -981,7 +981,9 @@ export function useVehicleSystems(
     }
     
     const updatedCars: Car[] = [];
-    for (const car of carsRef.current) {
+    const cars = carsRef.current;
+    for (let i = 0; i < cars.length; i++) {
+      const car = cars[i];
       // Update car age and remove if too old
       car.age += delta * speedMultiplier;
       if (car.age > car.maxAge) {
@@ -1217,8 +1219,10 @@ export function useVehicleSystems(
     const lightState = getTrafficLightState(trafficTime);
 
     const updatedBuses: Bus[] = [];
+    const buses = busesRef.current;
 
-    for (const bus of busesRef.current) {
+    for (let i = 0; i < buses.length; i++) {
+      const bus = buses[i];
       bus.age += delta * speedMultiplier;
       if (bus.age > bus.maxAge) {
         continue;

--- a/src/components/game/vehicleSystems.ts
+++ b/src/components/game/vehicleSystems.ts
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react';
 import { Bus, Car, CarDirection, EmergencyVehicle, EmergencyVehicleType, Pedestrian, PedestrianDestType, WorldRenderState, TILE_WIDTH, TILE_HEIGHT } from './types';
 import { BUS_COLORS, BUS_MIN_POPULATION, BUS_MIN_ZOOM, BUS_SPEED_MAX, BUS_SPEED_MIN, BUS_SPAWN_INTERVAL_MAX, BUS_SPAWN_INTERVAL_MIN, BUS_STOP_DURATION_MAX, BUS_STOP_DURATION_MIN, CAR_COLORS, CAR_MIN_ZOOM, CAR_MIN_ZOOM_MOBILE, DIRECTION_META, MAX_BUSES, MAX_BUSES_MOBILE, PEDESTRIAN_MAX_COUNT, PEDESTRIAN_MAX_COUNT_MOBILE, PEDESTRIAN_MIN_ZOOM, PEDESTRIAN_MIN_ZOOM_MOBILE, PEDESTRIAN_ROAD_TILE_DENSITY, PEDESTRIAN_ROAD_TILE_DENSITY_MOBILE, PEDESTRIAN_SPAWN_BATCH_SIZE, PEDESTRIAN_SPAWN_BATCH_SIZE_MOBILE, PEDESTRIAN_SPAWN_INTERVAL, PEDESTRIAN_SPAWN_INTERVAL_MOBILE, VEHICLE_FAR_ZOOM_THRESHOLD } from './constants';
 import { isRoadTile, getDirectionOptions, pickNextDirection, findPathOnRoads, getDirectionToTile, gridToScreen } from './utils';
-import { findBusStops, findResidentialBuildings, findPedestrianDestinations, findStations, findFires, findRecreationAreas, findEnterableBuildings, SPORTS_TYPES, ACTIVE_RECREATION_TYPES } from './gridFinders';
+import { findBusStops, findResidentialBuildings, findPedestrianDestinations, findStations, findFires, findRecreationAreas, findEnterableBuildings, SPORTS_TYPES_SET, ACTIVE_RECREATION_TYPES_SET } from './gridFinders';
 import { drawPedestrians as drawPedestriansUtil } from './drawPedestrians';
 import { BuildingType, Tile } from '@/types/game';
 import { getTrafficLightState, canProceedThroughIntersection, TRAFFIC_LIGHT_TIMING } from './trafficSystem';
@@ -19,6 +19,9 @@ import {
   getRandomBeachTile,
   spawnPedestrianAtBeach,
 } from './pedestrianSystem';
+
+// PERF: Hoisted so isVehicleBehindBuilding does not allocate a skip list per call
+const VEHICLE_SKIP_BUILDING_TYPES = new Set<BuildingType>(['road', 'grass', 'empty', 'water', 'tree']);
 
 /** Train type for crossing detection (minimal interface) */
 export interface TrainForCrossing {
@@ -323,7 +326,7 @@ export function useVehicleSystems(
           if (d.type !== 'park') return false;
           const tile = currentGrid[d.y]?.[d.x];
           const buildingType = tile?.building.type;
-          return buildingType && (SPORTS_TYPES.includes(buildingType) || ACTIVE_RECREATION_TYPES.includes(buildingType));
+          return buildingType && (SPORTS_TYPES_SET.has(buildingType) || ACTIVE_RECREATION_TYPES_SET.has(buildingType));
         });
         if (boostedDests.length > 0) {
           dest = boostedDests[Math.floor(Math.random() * boostedDests.length)];
@@ -383,7 +386,7 @@ export function useVehicleSystems(
       // 50% chance to re-roll and pick a sports/active facility if available
       if (Math.random() < 0.5) {
         const sportsAreas = recreationAreas.filter(a => 
-          SPORTS_TYPES.includes(a.buildingType) || ACTIVE_RECREATION_TYPES.includes(a.buildingType)
+          SPORTS_TYPES_SET.has(a.buildingType) || ACTIVE_RECREATION_TYPES_SET.has(a.buildingType)
         );
         if (sportsAreas.length > 0) {
           area = sportsAreas[Math.floor(Math.random() * sportsAreas.length)];
@@ -978,7 +981,7 @@ export function useVehicleSystems(
     }
     
     const updatedCars: Car[] = [];
-    for (const car of [...carsRef.current]) {
+    for (const car of carsRef.current) {
       // Update car age and remove if too old
       car.age += delta * speedMultiplier;
       if (car.age > car.maxAge) {
@@ -1215,7 +1218,7 @@ export function useVehicleSystems(
 
     const updatedBuses: Bus[] = [];
 
-    for (const bus of [...busesRef.current]) {
+    for (const bus of busesRef.current) {
       bus.age += delta * speedMultiplier;
       if (bus.age > bus.maxAge) {
         continue;
@@ -1439,14 +1442,28 @@ export function useVehicleSystems(
     ctx.save();
     ctx.scale(dpr * currentZoom, dpr * currentZoom);
     ctx.translate(currentOffset.x / currentZoom, currentOffset.y / currentZoom);
-    
-    carsRef.current.forEach(car => {
+
+    const viewWidth = canvas.width / (dpr * currentZoom);
+    const viewHeight = canvas.height / (dpr * currentZoom);
+    const viewLeft = -currentOffset.x / currentZoom - TILE_WIDTH;
+    const viewTop = -currentOffset.y / currentZoom - TILE_HEIGHT * 2;
+    const viewRight = viewWidth - currentOffset.x / currentZoom + TILE_WIDTH;
+    const viewBottom = viewHeight - currentOffset.y / currentZoom + TILE_HEIGHT * 2;
+
+    const cars = carsRef.current;
+    for (let i = 0; i < cars.length; i++) {
+      const car = cars[i];
       const { screenX, screenY } = gridToScreen(car.tileX, car.tileY, 0, 0);
       const centerX = screenX + TILE_WIDTH / 2;
       const centerY = screenY + TILE_HEIGHT / 2;
       const meta = DIRECTION_META[car.direction];
       const carX = centerX + meta.vec.dx * car.progress + meta.normal.nx * car.laneOffset;
       const carY = centerY + meta.vec.dy * car.progress + meta.normal.ny * car.laneOffset;
+
+      // Cars are small — tight margin is enough to avoid edge pop-in
+      if (carX < viewLeft - 20 || carX > viewRight + 20 || carY < viewTop - 20 || carY > viewBottom + 20) {
+        continue;
+      }
       
       ctx.save();
       ctx.translate(carX, carY);
@@ -1471,7 +1488,7 @@ export function useVehicleSystems(
       ctx.fillRect(-10 * scale, -4 * scale, 2.4 * scale, 8 * scale);
       
       ctx.restore();
-    });
+    }
     
     ctx.restore();
   }, [worldStateRef, carsRef, isMobile]);
@@ -1500,7 +1517,9 @@ export function useVehicleSystems(
     const viewRight = viewWidth - currentOffset.x / currentZoom + TILE_WIDTH;
     const viewBottom = viewHeight - currentOffset.y / currentZoom + TILE_HEIGHT * 2;
 
-    busesRef.current.forEach(bus => {
+    const buses = busesRef.current;
+    for (let i = 0; i < buses.length; i++) {
+      const bus = buses[i];
       const { screenX, screenY } = gridToScreen(bus.tileX, bus.tileY, 0, 0);
       const centerX = screenX + TILE_WIDTH / 2;
       const centerY = screenY + TILE_HEIGHT / 2;
@@ -1509,7 +1528,7 @@ export function useVehicleSystems(
       const busY = centerY + meta.vec.dy * bus.progress + meta.normal.ny * bus.laneOffset;
 
       if (busX < viewLeft - 60 || busX > viewRight + 60 || busY < viewTop - 80 || busY > viewBottom + 80) {
-        return;
+        continue;
       }
 
       ctx.save();
@@ -1527,8 +1546,8 @@ export function useVehicleSystems(
       ctx.fillRect(-length * 0.8, -width * 0.7, length * 1.4, width * 0.9);
 
       ctx.fillStyle = 'rgba(191, 219, 254, 0.8)';
-      for (let i = 0; i < 4; i++) {
-        const wx = -length * 0.7 + i * length * 0.45;
+      for (let wi = 0; wi < 4; wi++) {
+        const wx = -length * 0.7 + wi * length * 0.45;
         ctx.fillRect(wx, -width * 0.55, length * 0.25, width * 1.1);
       }
 
@@ -1539,7 +1558,7 @@ export function useVehicleSystems(
       ctx.fillRect(length * 0.85, -width * 0.35, length * 0.1, width * 0.7);
 
       ctx.restore();
-    });
+    }
 
     ctx.restore();
   }, [worldStateRef, busesRef]);
@@ -1652,8 +1671,7 @@ export function useVehicleSystems(
           if (!tile) continue;
           
           const buildingType = tile.building.type;
-          const skipTypes: BuildingType[] = ['road', 'grass', 'empty', 'water', 'tree'];
-          if (skipTypes.includes(buildingType)) {
+          if (VEHICLE_SKIP_BUILDING_TYPES.has(buildingType)) {
             continue;
           }
           
@@ -1667,7 +1685,9 @@ export function useVehicleSystems(
       return false;
     };
     
-    emergencyVehiclesRef.current.forEach(vehicle => {
+    const emergencyVehicles = emergencyVehiclesRef.current;
+    for (let i = 0; i < emergencyVehicles.length; i++) {
+      const vehicle = emergencyVehicles[i];
       const { screenX, screenY } = gridToScreen(vehicle.tileX, vehicle.tileY, 0, 0);
       const centerX = screenX + TILE_WIDTH / 2;
       const centerY = screenY + TILE_HEIGHT / 2;
@@ -1676,7 +1696,7 @@ export function useVehicleSystems(
       const vehicleY = centerY + meta.vec.dy * vehicle.progress + meta.normal.ny * vehicle.laneOffset;
       
       if (vehicleX < viewLeft - 40 || vehicleX > viewRight + 40 || vehicleY < viewTop - 60 || vehicleY > viewBottom + 60) {
-        return;
+        continue;
       }
       
       ctx.save();
@@ -1739,7 +1759,7 @@ export function useVehicleSystems(
       ctx.fillRect(-length * scale, -4 * scale, 2 * scale, 8 * scale);
       
       ctx.restore();
-    });
+    }
     
     ctx.restore();
   }, [worldStateRef, emergencyVehiclesRef]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small, focused performance improvements on vehicle/pathfinding hot paths:

- **`findPathOnRoads`**: stamp visited cells with a generation id (skip clearing the whole grid each pathfind) and store parent queue indices so path reconstruction is O(path length) instead of a linear search per step.
- **`gridFinders`**: convert sports/relaxation/active-recreation/enterable building type lists to Sets for O(1) `.has()` checks; keep array exports for iteration.
- **`vehicleSystems`**: iterate cars/buses without per-frame array copies (local indexed loops); draw cars/buses/emergency vehicles with `for` loops; add viewport culling for cars; hoist vehicle occlusion skip types to a module-level Set.

## Testing

- [x] `npm run build` (type-check + production compile)
- [x] ESLint clean on touched files
- [x] Manual smoke on IsoCity: roads placed, cars spawn/move/turn at intersections; pan + zoom remain smooth
- [x] Algorithm check: generation-stamp BFS matches clear-style BFS on sample road graphs (0 mismatches)

[City with traffic](https://cursor.com/agents/bc-01a063d0-0e4a-7afc-b4f3-d2773c27a21c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisocity-city-with-traffic.webp)
[Vehicles on roads](https://cursor.com/agents/bc-01a063d0-0e4a-7afc-b4f3-d2773c27a21c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisocity-vehicles-on-roads.webp)
[isocity-vehicle-traffic-demo.mp4](https://cursor.com/agents/bc-01a063d0-0e4a-7afc-b4f3-d2773c27a21c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisocity-vehicle-traffic-demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a063d0-0e4a-7afc-b4f3-d2773c27a21c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a063d0-0e4a-7afc-b4f3-d2773c27a21c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves road pathfinding, building lookups, and vehicle update/render hot paths so larger cities run more smoothly.

- Uses generation-stamped visits and parent queue indices to reduce BFS setup and path reconstruction work.
- Replaces repeated building-type scans with `Set` lookups while preserving array exports for iteration.
- Uses indexed vehicle loops without per-frame array copies, culls offscreen cars, and reuses the vehicle occlusion skip set.

<sup>Written for commit e5a751bf189f4a80260c9e9617f76afd269808d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/amilich/isometric-city/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

